### PR TITLE
Fix string-format in warning for inductive types

### DIFF
--- a/Auto/Translation/Inductive.lean
+++ b/Auto/Translation/Inductive.lean
@@ -112,7 +112,7 @@ mutual
     let .some (.inductInfo val) := (← getEnv).find? tyctor
       | return
     if !(← @id (CoreM _) (val.all.allM isSimpleInductive)) then
-      trace[auto.collectInd] (s!"Warning : {tyctor} or some type within the " ++
+      trace[auto.collectInd] (m!"Warning : {tyctor} or some type within the " ++
         "same mutual block is not a simple inductive type. Ignoring it ...")
       return
     /-


### PR DESCRIPTION
This printed the fixed string "{tyctor}". The formatting syntax works by default following `trace`, but not in the context of `(_ ++ _)`.