### PR TITLE
Add support for SMT triggers

### DIFF
--- a/Auto/IR/SMT.lean
+++ b/Auto/IR/SMT.lean
@@ -118,6 +118,22 @@ end
 
 def STerm.qStrApp (s : String) (arr : Array STerm) := STerm.qIdApp (.ofString s) arr
 
+def STerm.attrApp (name : String) (attrTerm : STerm) (term : STerm) : STerm :=
+  match term with
+  | .attr term' attrs' => .attr term' (#[attr] ++ attrs')
+  | _ => .attr term #[attr]
+  where
+    attr :=
+      match attrTerm with
+      -- An empty string constant indicates an attribute with no arguments
+      | .sConst (.str "") => .none name
+      -- Other string constants are always symbols here.
+      | .sConst (.str sym) => .symb name sym
+      -- Other constants are constant arguments.
+      | .sConst c => .spec name c
+      -- Non-constant arguments are terms.
+      | t => .sexpr name #[t]
+
 private partial def STerm.toStringAux : STerm → List SIdent → String
   | .sConst c, _         => SpecConst.toString c
   | .bvar i, binders   =>

--- a/Auto/IR/TPTP_TH0.lean
+++ b/Auto/IR/TPTP_TH0.lean
@@ -82,6 +82,8 @@ def transLamBaseTerm : LamBaseTerm → Except String String
 | .icst ic    => .ok (transIntConst ic)
 | .scst sc    => .ok (transStringConst sc)
 | .bvcst bvc  => .ok (transBitVecConst bvc)
+-- TODO: translate to λx => x?
+| .ocst _     => .error "transLamBaseTerm :: attributes not supported in TPTP"
 | .eqI _      => .error "transLamBaseTerm :: eqI should not occur here"
 | .forallEI _ => .error "transLamBaseTerm :: forallEI should not occur here"
 | .existEI _  => .error "transLamBaseTerm :: existEI should not occur here"

--- a/Auto/Translation/Lam2D.lean
+++ b/Auto/Translation/Lam2D.lean
@@ -253,6 +253,7 @@ def interpLamBaseTermAsUnlifted : LamBaseTerm → ExternM Expr
 | .icst ic    => return interpIntConstAsUnlifted ic
 | .scst sc    => return interpStringConstAsUnlifted sc
 | .bvcst bvc  => return interpBitVecConstAsUnlifted bvc
+| .ocst _     => throwError ("interpLamTermAsUnlifted :: Attributes not supported")
 | .eqI _      => throwError ("interpLamTermAsUnlifted :: " ++ exportError.ImpPolyLog)
 | .forallEI _ => throwError ("interpLamTermAsUnlifted :: " ++ exportError.ImpPolyLog)
 | .existEI _  => throwError ("interpLamTermAsUnlifted :: " ++ exportError.ImpPolyLog)

--- a/Auto/Translation/LamFOL2SMT.lean
+++ b/Auto/Translation/LamFOL2SMT.lean
@@ -164,6 +164,7 @@ private def lamBaseTerm2STerm_Arity2 (arg1 arg2 : STerm) : LamBaseTerm → Trans
     | .lshr => return .qStrApp "bvlshr" #[arg1, arg2]
     | .ashr => return .qStrApp "bvashr" #[arg1, arg2]
 | .bvcst (.bvappend _ _) => return .qStrApp "concat" #[arg1, arg2]
+| .ocst (.attribute s _) => return .attrApp s arg1 arg2
 | t           => throwError "lamTerm2STerm :: The arity of {repr t} is not 2"
 
 private def lamBaseTerm2STerm_Arity1 (arg : STerm) : LamBaseTerm → TransM LamAtom STerm

--- a/Auto/Translation/LamReif.lean
+++ b/Auto/Translation/LamReif.lean
@@ -1271,6 +1271,11 @@ def reifMapBVConst3 : HashMap Name (Nat → Nat → Nat → LamTerm) :=
     (``BitVec.extractLsb, fun n h l => .base (.bvextract n h l))
   ]
 
+def reifMapAttributes : HashMap Name String :=
+  HashMap.ofList [
+    (``trigger, "pattern")
+  ]
+
 def processSimpleLit (l : Literal) : LamTerm :=
   match l with
   | .natVal n => .base (.natVal n)
@@ -1307,6 +1312,10 @@ def processSimpleApp (fn arg : Expr) : ReifM (Option LamTerm) := do
       -- `arg` is the original (un-lifted) type
     if let .some tcon := reifMapIL.find? name then
       return .some (.base (tcon (← reifType arg)))
+    if let .some attrName := reifMapAttributes.find? name then
+      if lvls.length != 0 then
+        throwError "processSimpleApp :: attribute should have nil level list"
+      return .some (.base (.ocst (.attribute attrName (← reifType arg))))
     return .none
   | [arg₁, arg₂] =>
     if let .some tcon := reifMapBVConst2.find? name then

--- a/Test/SmtTranslation/Trigger.lean
+++ b/Test/SmtTranslation/Trigger.lean
@@ -1,0 +1,18 @@
+import Auto.Tactic
+import Auto.Embedding.LamBase
+open Auto.Embedding.Lam
+
+set_option auto.smt.trust true
+set_option trace.auto.smt.printCommands true
+set_option trace.auto.smt.result true
+set_option trace.auto.smt.unsatCore true
+set_option auto.smt.save true
+set_option auto.smt.savepath "output.smt2"
+
+set_option auto.smt true
+
+axiom f : Int -> Int
+
+axiom fGreater : forall x, trigger (f x) (f x > x)
+
+theorem fPlusOneGreater : forall x, (f x) + 1 > x := by auto [fGreater] u[]


### PR DESCRIPTION
This is implemented by allowing arbitrary attributes to be propagated throughout the pipeline. For the SMT backend, these are translated into SMT attributes. Currently, the only attribute supported is the `:pattern` attribute used to indicate triggers. Adding other attributes will be easy now that this plumbing is in place, however.

Attributes currently aren't supported for TPTP, but it should be possible to allow them eventually if there's a use for them.

Note that the initial construction of attributes is very general, and allows attributes of any base type supported by the translator. The set supported by SMT is more restricted, but other prover input languages may use entirely different attributes.

There's no attempt to ensure that attributes go in places that are allowed. So, for instance, adding a trigger outside of a quantified expression will lead to an error from the solver. Similarly, adding a trigger to a goal, rather than an axiom, will typically also lead to an error.

Fixes #3