### PR TITLE
Fix CVC5 model comments

### DIFF
--- a/Auto/Parser/SMTSexp.lean
+++ b/Auto/Parser/SMTSexp.lean
@@ -186,6 +186,7 @@ def parseSexp (s : String) (p : String.Pos) (partialResult : PartialResult) : Pa
             return .complete (.app final) p
           else
             pstk := pstk.modify (pstk.size - 1) (fun arr => arr.push (.app final))
+      | .comment s => pstk := pstk.modify (pstk.size - 1) (fun arr => arr.push (.atom (.comment s)))
       | l       =>
         -- Ordinary lexicons must be separated by whitespace or parentheses
         match s.get? p with


### PR DESCRIPTION
Previously they returned `.malformed` due to the whitespace check on L194-195.

Example file that would previously trigger the "Malformed" error message:

```Lean
import Auto

set_option auto.smt true
set_option trace.auto.smt.model true
set_option auto.smt.solver.name "cvc5"

theorem model1 {a : Type} (rel : a → a → Prop) (s1 s2 : a) :
  rel s1 s2 → rel s2 s1 := by
  auto
```