### PR TITLE
chore: upgrade Lean toolchain to v4.16.0

### DIFF
--- a/Auto/Embedding/LamBVarOp.lean
+++ b/Auto/Embedding/LamBVarOp.lean
@@ -91,7 +91,7 @@ theorem LamWF.mapBVarAt.correct (lval : LamValuation.{u}) {restoreDep : _}
   dsimp [LamWF.interp]
   let IHFn := LamWF.mapBVarAt.correct lval covPD idx lctxTerm fn wfFn
   let IHArg := LamWF.mapBVarAt.correct lval covPD idx lctxTerm arg wfArg
-  rw [IHFn]; rw [IHArg]
+  rw [IHFn]; rw [IHArg]; rfl
 
 /-- Changing all `.bvar ?n` in `t` (where `?n >= idx`) to `.bvar (?n + lvl)` -/
 def LamTerm.bvarLiftsIdx (idx lvl : Nat) := LamTerm.mapBVarAt idx (fun x => Nat.add x lvl)

--- a/Auto/Embedding/LamBase.lean
+++ b/Auto/Embedding/LamBase.lean
@@ -2673,101 +2673,101 @@ def LamTerm.mkNot (t : LamTerm) : LamTerm :=
 
 theorem LamTerm.maxEVarSucc_mkNot :
   (mkNot t).maxEVarSucc = t.maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [Nat.max, Nat.max_zero_left]
+  dsimp [mkNot, maxEVarSucc]; rw [Nat.max, Nat.max_zero_left]
 
 def LamTerm.mkAnd (t₁ t₂ : LamTerm) : LamTerm :=
   .app (.base .prop) (.app (.base .prop) (.base .and) t₁) t₂
 
 theorem LamTerm.maxEVarSucc_mkAnd :
   (mkAnd t₁ t₂).maxEVarSucc = max t₁.maxEVarSucc t₂.maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [Nat.max, Nat.max, Nat.max_zero_left]
+  dsimp [mkAnd, maxEVarSucc]; rw [Nat.max, Nat.max, Nat.max_zero_left]
 
 def LamTerm.mkOr (t₁ t₂ : LamTerm) : LamTerm :=
   .app (.base .prop) (.app (.base .prop) (.base .or) t₁) t₂
 
 theorem LamTerm.maxEVarSucc_mkOr :
   (mkOr t₁ t₂).maxEVarSucc = max t₁.maxEVarSucc t₂.maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [Nat.max, Nat.max, Nat.max_zero_left]
+  dsimp [mkOr, maxEVarSucc]; rw [Nat.max, Nat.max, Nat.max_zero_left]
 
 def LamTerm.mkImp (t₁ t₂ : LamTerm) : LamTerm :=
   .app (.base .prop) (.app (.base .prop) (.base .imp) t₁) t₂
 
 theorem LamTerm.maxEVarSucc_mkImp :
   (mkImp t₁ t₂).maxEVarSucc = max t₁.maxEVarSucc t₂.maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [Nat.max, Nat.max, Nat.max_zero_left]
+  dsimp [mkImp, maxEVarSucc]; rw [Nat.max, Nat.max, Nat.max_zero_left]
 
 def LamTerm.mkIff (t₁ t₂ : LamTerm) : LamTerm :=
   .app (.base .prop) (.app (.base .prop) (.base .iff) t₁) t₂
 
 theorem LamTerm.maxEVarSucc_mkIff :
   (mkIff t₁ t₂).maxEVarSucc = max t₁.maxEVarSucc t₂.maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [Nat.max, Nat.max, Nat.max_zero_left]
+  dsimp [mkIff, maxEVarSucc]; rw [Nat.max, Nat.max, Nat.max_zero_left]
 
 def LamTerm.mkEq (s : LamSort) (t₁ t₂ : LamTerm) : LamTerm :=
   .app s (.app s (.base (.eq s)) t₁) t₂
 
 theorem LamTerm.maxLooseBVarSucc_mkEq :
   (mkEq s t₁ t₂).maxLooseBVarSucc = max t₁.maxLooseBVarSucc t₂.maxLooseBVarSucc := by
-  dsimp [maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
+  dsimp [mkEq, maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
 
 theorem LamTerm.maxEVarSucc_mkEq :
   (mkEq s t₁ t₂).maxEVarSucc = max t₁.maxEVarSucc t₂.maxEVarSucc := by
-  dsimp [maxEVarSucc, Nat.max]; rw[Nat.max_zero_left]
+  dsimp [mkEq, maxEVarSucc, Nat.max]; rw [Nat.max_zero_left]
 
 def LamTerm.mkForallE (s : LamSort) (p : LamTerm) : LamTerm :=
   .app (.func s (.base .prop)) (.base (.forallE s)) p
 
 theorem LamTerm.maxLooseBVarSucc_mkForallE :
   (mkForallE s p).maxLooseBVarSucc = p.maxLooseBVarSucc := by
-  dsimp [maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
+  dsimp [mkForallE, maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
 
 theorem LamTerm.maxEVarSucc_mkForallE :
   (mkForallE s p).maxEVarSucc = p.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkForallE, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkForallEF (s : LamSort) (p : LamTerm) : LamTerm :=
   .app (.func s (.base .prop)) (.base (.forallE s)) (.lam s p)
 
 theorem LamTerm.maxLooseBVarSucc_mkForallEF :
   (mkForallEF s p).maxLooseBVarSucc = p.maxLooseBVarSucc.pred := by
-  dsimp [maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
+  dsimp [mkForallEF, maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
 
 theorem LamTerm.maxEVarSucc_mkForallEF :
   (mkForallEF s p).maxEVarSucc = p.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkForallEF, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkExistE (s : LamSort) (p : LamTerm) : LamTerm :=
   .app (.func s (.base .prop)) (.base (.existE s)) p
 
 theorem LamTerm.maxLooseBVarSucc_mkExistE :
   (mkExistE s p).maxLooseBVarSucc = p.maxLooseBVarSucc := by
-  dsimp [maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
+  dsimp [mkExistE, maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
 
 theorem LamTerm.maxEVarSucc_mkExistE :
   (mkExistE s p).maxEVarSucc = p.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkExistE, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkExistEF (s : LamSort) (p : LamTerm) : LamTerm :=
   .app (.func s (.base .prop)) (.base (.existE s)) (.lam s p)
 
 theorem LamTerm.maxLooseBVarSucc_mkExistEF :
   (mkExistEF s p).maxLooseBVarSucc = p.maxLooseBVarSucc.pred := by
-  dsimp [maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
+  dsimp [mkExistEF, maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
 
 theorem LamTerm.maxEVarSucc_mkExistEF :
   (mkExistEF s p).maxEVarSucc = p.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkExistEF, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkIte (s : LamSort) (b x y : LamTerm) : LamTerm :=
   .app s (.app s (.app (.base .prop) (.base (.ite s)) b) x) y
 
 theorem LamTerm.maxLooseBVarSucc_mkIte :
   (mkIte s b x y).maxLooseBVarSucc = max (max b.maxLooseBVarSucc x.maxLooseBVarSucc) y.maxLooseBVarSucc := by
-  dsimp [maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
+  dsimp [mkIte, maxLooseBVarSucc, Nat.max]; rw [Nat.max_zero_left]
 
 theorem LamTerm.maxEVarSucc_mkIte :
   (mkIte s b x y).maxEVarSucc = max (max b.maxEVarSucc x.maxEVarSucc) y.maxEVarSucc := by
-  dsimp [maxEVarSucc, Nat.max]; rw [Nat.max_zero_left]
+  dsimp [mkIte, maxEVarSucc, Nat.max]; rw [Nat.max_zero_left]
 
 def LamTerm.mkNatVal (n : Nat) : LamTerm := .base (.natVal n)
 
@@ -2778,35 +2778,35 @@ def LamTerm.mkNatBinOp (binOp : NatConst) (a b : LamTerm) : LamTerm :=
 
 theorem LamTerm.maxEVarSucc_mkNatBinOp :
   (mkNatBinOp op a b).maxEVarSucc = max a.maxEVarSucc b.maxEVarSucc := by
-  dsimp [maxEVarSucc]; simp [Nat.max, Nat.max_zero_left]
+  dsimp [mkNatBinOp, maxEVarSucc]; simp [Nat.max, Nat.max_zero_left]
 
 def LamTerm.mkIOfNat (n : LamTerm) : LamTerm :=
   .app (.base .nat) (.base .iofNat) n
 
 theorem LamTerm.maxEVarSucc_mkIOfNat :
   (mkIOfNat n).maxEVarSucc = n.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkIOfNat, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkINegSucc (n : LamTerm) : LamTerm :=
   .app (.base .nat) (.base .inegSucc) n
 
 theorem LamTerm.maxEVarSucc_mkINegSucc :
   (mkINegSucc n).maxEVarSucc = n.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkINegSucc, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkIntUOp (uop : IntConst) (a : LamTerm) : LamTerm :=
   .app (.base .int) (.base (.icst uop)) a
 
 theorem LamTerm.maxEVarSucc_mkIntUOp :
   (mkIntUOp uop n).maxEVarSucc = n.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkIntUOp, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkIntBinOp (binOp : IntConst) (a b : LamTerm) : LamTerm :=
   .app (.base .int) (.app (.base .int) (.base (.icst binOp)) a) b
 
 theorem LamTerm.maxEVarSucc_mkIntBinOp :
   (mkIntBinOp op a b).maxEVarSucc = max a.maxEVarSucc b.maxEVarSucc := by
-  dsimp [maxEVarSucc]; simp [Nat.max, Nat.max_zero_left]
+  dsimp [mkIntBinOp, maxEVarSucc]; simp [Nat.max, Nat.max_zero_left]
 
 /-- Make `BitVec.ofNat n i` -/
 def LamTerm.mkBvofNat (n : Nat) (i : LamTerm) : LamTerm :=
@@ -2814,7 +2814,7 @@ def LamTerm.mkBvofNat (n : Nat) (i : LamTerm) : LamTerm :=
 
 theorem LamTerm.maxEVarSucc_mkBvofNat :
   (mkBvofNat n i).maxEVarSucc = i.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkBvofNat, maxEVarSucc]; apply Nat.max_zero_left
 
 /-- Make `BitVec.ofInt n i` -/
 def LamTerm.mkBvofInt (n : Nat) (i : LamTerm) : LamTerm :=
@@ -2822,28 +2822,28 @@ def LamTerm.mkBvofInt (n : Nat) (i : LamTerm) : LamTerm :=
 
 theorem LamTerm.maxEVarSucc_mkBvofInt :
   (mkBvofInt n i).maxEVarSucc = i.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkBvofInt, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkBvUOp (n : Nat) (uop : BitVecConst) (a : LamTerm) : LamTerm :=
   .app (.base (.bv n)) (.base (.bvcst uop)) a
 
 theorem LamTerm.maxEVarSucc_mkBvUOp :
   (mkBvUOp n uop a).maxEVarSucc = a.maxEVarSucc := by
-  dsimp [maxEVarSucc]; apply Nat.max_zero_left
+  dsimp [mkBvUOp, maxEVarSucc]; apply Nat.max_zero_left
 
 def LamTerm.mkBvBinOp (n : Nat) (binOp : BitVecConst) (a b : LamTerm) : LamTerm :=
   .app (.base (.bv n)) (.app (.base (.bv n)) (.base (.bvcst binOp)) a) b
 
 theorem LamTerm.maxEVarSucc_mkBvBinOp :
   (mkBvBinOp n binOp a b).maxEVarSucc = max a.maxEVarSucc b.maxEVarSucc := by
-  dsimp [maxEVarSucc]; simp [Nat.max, Nat.max_zero_left]
+  dsimp [mkBvBinOp, maxEVarSucc]; simp [Nat.max, Nat.max_zero_left]
 
 def LamTerm.mkBvNatBinOp (n : Nat) (binOp : BitVecConst) (a b : LamTerm) : LamTerm :=
   .app (.base .nat) (.app (.base (.bv n)) (.base (.bvcst binOp)) a) b
 
 theorem LamTerm.maxEVarSucc_mkBvNatBinOp :
   (mkBvNatBinOp n binOp a b).maxEVarSucc = max a.maxEVarSucc b.maxEVarSucc := by
-  dsimp [maxEVarSucc]; simp [Nat.max, Nat.max_zero_left]
+  dsimp [mkBvNatBinOp, maxEVarSucc]; simp [Nat.max, Nat.max_zero_left]
 
 def LamTerm.mkAppN (t : LamTerm) : List (LamSort × LamTerm) → LamTerm
 | .nil => t
@@ -2891,7 +2891,7 @@ theorem LamTerm.maxEVarSucc_mkForallEFN {t : LamTerm} :
   induction lctx generalizing t
   case nil => rfl
   case cons s lctx IH =>
-    dsimp [mkForallEFN, maxEVarSucc]; rw [IH]
+    dsimp [mkForallEF, mkForallEFN, maxEVarSucc]; rw [IH]
     rw [Nat.max, Nat.max_zero_left]
 
 theorem LamTerm.mkForallEFN_append :
@@ -4167,7 +4167,7 @@ theorem LamWF.interp_bvarApps
   case cons lty lctx lx lctxTerm IH =>
     dsimp [LamSort.mkFuncsRev] at wft
     dsimp [LamTerm.bvarApps] at wfAp; cases wfAp; case ofApp HArg HFn =>
-      dsimp [interp]; apply congr_hd_heq (f₂:=fun lx =>valPre (HList.cons lx lctxTerm)) (x₂:=lx) <;> try rfl
+      apply congr_hd_heq (f₂:=fun lx =>valPre (HList.cons lx lctxTerm)) (x₂:=lx) <;> try rfl
       case h₁ =>
         apply @IH (lty::tyex) (.func lty s) wft _ (fun lctxTerm lx => valPre (.cons lx lctxTerm)) (.cons lx termex) ht
       case h₂ =>

--- a/Auto/Embedding/LamBitVec.lean
+++ b/Auto/Embedding/LamBitVec.lean
@@ -385,7 +385,7 @@ theorem LamTerm.congr_maxEVarSucc_shl_equiv
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂)
   (eqbbv : maxEVarSucc bbv₁ = maxEVarSucc bbv₂) :
   (shl_equiv n₁ a₁ b₁ bbv₁).maxEVarSucc = (shl_equiv n₂ a₂ b₂ bbv₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb, eqbbv]
+  dsimp [shl_equiv, mkIte, mkNatBinOp, mkBvBinOp, maxEVarSucc]; rw [eqa, eqb, eqbbv]
 
 theorem LamEquiv.congr_shl_equiv
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -415,7 +415,7 @@ theorem LamTerm.congr_maxEVarSucc_shl_toNat_equiv_short
   (eqa : maxEVarSucc a₁ = maxEVarSucc a₂)
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂) :
   (shl_toNat_equiv_short n₁ a₁ m₁ b₁).maxEVarSucc = (shl_toNat_equiv_short n₂ a₂ m₂ b₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb]
+  dsimp [shl_toNat_equiv_short, mkBvBinOp, mkBvUOp, maxEVarSucc]; rw [eqa, eqb]
 
 theorem LamEquiv.congr_shl_toNat_equiv_short
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -443,7 +443,7 @@ theorem LamTerm.congr_maxEVarSucc_shl_toNat_equiv_long
   (eqa : maxEVarSucc a₁ = maxEVarSucc a₂)
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂) :
   (shl_toNat_equiv_long n₁ a₁ m₁ b₁).maxEVarSucc = (shl_toNat_equiv_long n₂ a₂ m₂ b₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb]
+  dsimp [shl_toNat_equiv_long, mkIte, mkEq, mkBvBinOp, mkBvUOp, maxEVarSucc]; rw [eqa, eqb]
 
 theorem LamEquiv.congr_shl_toNat_equiv_long
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -478,7 +478,7 @@ theorem LamTerm.congr_maxEVarSucc_lshr_equiv
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂)
   (eqbbv : maxEVarSucc bbv₁ = maxEVarSucc bbv₂) :
   (lshr_equiv n₁ a₁ b₁ bbv₁).maxEVarSucc = (lshr_equiv n₂ a₂ b₂ bbv₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb, eqbbv]
+  dsimp [lshr_equiv, mkIte, mkNatBinOp, mkBvBinOp, maxEVarSucc]; rw [eqa, eqb, eqbbv]
 
 theorem LamEquiv.congr_lshr_equiv
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -507,7 +507,7 @@ theorem LamTerm.congr_maxEVarSucc_lshr_toNat_equiv_short
   (eqa : maxEVarSucc a₁ = maxEVarSucc a₂)
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂) :
   (lshr_toNat_equiv_short n₁ a₁ m₁ b₁).maxEVarSucc = (lshr_toNat_equiv_short n₂ a₂ m₂ b₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb]
+  dsimp [lshr_toNat_equiv_short, mkBvBinOp, mkBvUOp, maxEVarSucc]; rw [eqa, eqb]
 
 theorem LamEquiv.congr_lshr_toNat_equiv_short
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -535,7 +535,7 @@ theorem LamTerm.congr_maxEVarSucc_lshr_toNat_equiv_long
   (eqa : maxEVarSucc a₁ = maxEVarSucc a₂)
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂) :
   (lshr_toNat_equiv_long n₁ a₁ m₁ b₁).maxEVarSucc = (lshr_toNat_equiv_long n₂ a₂ m₂ b₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb]
+  dsimp [lshr_toNat_equiv_long, mkIte, mkEq, mkBvBinOp, mkBvUOp, maxEVarSucc]; rw [eqa, eqb]
 
 theorem LamEquiv.congr_lshr_toNat_equiv_long
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -572,7 +572,7 @@ theorem LamTerm.congr_maxEVarSucc_ashr_equiv
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂)
   (eqbbv : maxEVarSucc bbv₁ = maxEVarSucc bbv₂) :
   (ashr_equiv n₁ a₁ b₁ bbv₁).maxEVarSucc = (ashr_equiv n₂ a₂ b₂ bbv₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb, eqbbv]
+  dsimp [ashr_equiv, mkIte, mkEq, mkNatBinOp, mkBvUOp, mkBvBinOp, maxEVarSucc]; rw [eqa, eqb, eqbbv]
 
 theorem LamEquiv.congr_ashr_equiv
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -607,7 +607,7 @@ theorem LamTerm.congr_maxEVarSucc_ashr_toNat_equiv_short
   (eqa : maxEVarSucc a₁ = maxEVarSucc a₂)
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂) :
   (ashr_toNat_equiv_short n₁ a₁ m₁ b₁).maxEVarSucc = (ashr_toNat_equiv_short n₂ a₂ m₂ b₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb]
+  dsimp [ashr_toNat_equiv_short, mkBvUOp, mkBvBinOp, maxEVarSucc]; rw [eqa, eqb]
 
 theorem LamEquiv.congr_ashr_toNat_equiv_short
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -638,7 +638,7 @@ theorem LamTerm.congr_maxEVarSucc_ashr_toNat_equiv_long
   (eqa : maxEVarSucc a₁ = maxEVarSucc a₂)
   (eqb : maxEVarSucc b₁ = maxEVarSucc b₂) :
   (ashr_toNat_equiv_long n₁ a₁ m₁ b₁).maxEVarSucc = (ashr_toNat_equiv_long n₂ a₂ m₂ b₂).maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [eqa, eqb]
+  dsimp [ashr_toNat_equiv_long, mkIte, mkEq, mkBvUOp, mkBvBinOp, maxEVarSucc]; rw [eqa, eqb]
 
 theorem LamEquiv.congr_ashr_toNat_equiv_long
   (eqa : LamEquiv lval lctx (.base (.bv n)) a₁ a₂)
@@ -754,10 +754,11 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
             cases b <;> try apply Nat.max_zero_left
             case ncst nc =>
               cases nc <;> (try apply Nat.max_zero_left) <;> try (
-                dsimp [pushBVCast, maxEVarSucc]
-                rw [IH (Nat.le_trans LamTerm.size_app_ge_size_arg leFn), IH leArg])
+                dsimp [pushBVCast, maxEVarSucc, mkBvBinOp]
+                simp [IH (Nat.le_trans LamTerm.size_app_ge_size_arg leFn), IH leArg])
               case nsub =>
-                simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right, Nat.max_eq_left (Nat.le_refl _)]
+                dsimp [pushBVCast, maxEVarSucc, bvofNat_nsub, mkIte, mkBvBinOp, mkNatBinOp, Nat.max]
+                simp [IH (Nat.le_trans LamTerm.size_app_ge_size_arg leFn), IH leArg]
       case ofInt m => apply Nat.max_zero_left
       case none =>
         have fneq := fun ct => @IH ct _ leFn
@@ -794,7 +795,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                     Eq.trans (LamTerm.congr_maxEVarSucc_shl_equiv (n₁:=n) (n₂:=n)
                       (argeq₁ .none) (argeq .none) (argeq (.ofNat n)))
                       (by
-                        dsimp [maxEVarSucc, pushBVCast]
+                        dsimp [shl_equiv, mkIte, mkNatBinOp, mkBvBinOp, mkBvNatBinOp, maxEVarSucc, pushBVCast]
                         simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right]
                         apply maxlem₁)
                   cases arg
@@ -808,7 +809,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                         cases bvc
                         case bvtoNat m =>
                           dsimp [maxEVarSucc, pushBVCast]
-                          cases m.ble n <;> dsimp [maxEVarSucc] <;> rw [argeq₁, argeq₂]
+                          cases m.ble n <;> dsimp [shl_toNat_equiv_short, shl_toNat_equiv_long, mkIte, mkEq, mkBvUOp, mkBvBinOp, maxEVarSucc] <;> rw [argeq₁, argeq₂]
                           simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right, maxlem₁]
                         all_goals apply h_none_shl
                       all_goals apply h_none_shl
@@ -821,7 +822,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                     Eq.trans (LamTerm.congr_maxEVarSucc_lshr_equiv (n₁:=n) (n₂:=n)
                       (argeq₁ .none) (argeq .none) (argeq (.ofNat n)))
                       (by
-                        dsimp [maxEVarSucc, pushBVCast]
+                        dsimp [lshr_equiv, mkIte, mkNatBinOp, mkBvBinOp, mkBvNatBinOp, maxEVarSucc, pushBVCast]
                         simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right]
                         apply maxlem₁)
                   cases arg
@@ -835,7 +836,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                         cases bvc
                         case bvtoNat m =>
                           dsimp [maxEVarSucc, pushBVCast]
-                          cases m.ble n <;> dsimp [maxEVarSucc] <;> rw [argeq₁, argeq₂]
+                          cases m.ble n <;> dsimp [lshr_toNat_equiv_short , lshr_toNat_equiv_long, mkIte, mkEq, mkBvUOp, mkBvBinOp, maxEVarSucc] <;> rw [argeq₁, argeq₂]
                           simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right, maxlem₁]
                         all_goals apply h_none_lshr
                       all_goals apply h_none_lshr
@@ -848,7 +849,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                     Eq.trans (LamTerm.congr_maxEVarSucc_ashr_equiv (n₁:=n) (n₂:=n)
                       (argeq₁ .none) (argeq .none) (argeq (.ofNat n)))
                       (by
-                        dsimp [maxEVarSucc, pushBVCast]
+                        dsimp [ashr_equiv, mkIte, mkEq, mkNatBinOp, mkBvUOp, mkBvBinOp, mkBvNatBinOp, maxEVarSucc, pushBVCast]
                         simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right]
                         apply maxlem₂)
                   cases arg
@@ -862,7 +863,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                         cases bvc
                         case bvtoNat m =>
                           dsimp [maxEVarSucc, pushBVCast]
-                          cases m.ble n <;> dsimp [maxEVarSucc] <;> rw [argeq₁, argeq₂]
+                          cases m.ble n <;> dsimp [ashr_toNat_equiv_short, ashr_toNat_equiv_long, mkIte, mkEq, mkBvUOp, mkBvBinOp, maxEVarSucc] <;> rw [argeq₁, argeq₂]
                           simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right, maxlem₂]
                         all_goals apply h_none_ashr
                       all_goals apply h_none_ashr

--- a/Auto/Embedding/LamConv.lean
+++ b/Auto/Embedding/LamConv.lean
@@ -13,13 +13,13 @@ theorem LamWF.interp_app_bvarLift_bvar0
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, .func argTy resTy⟩) :
   LamWF.interp lval (pushLCtx argTy lctx) (pushLCtxDep x lctxTerm) wft.app_bvarLift_bvar0 =
     LamWF.interp (rty:=.func _ _) lval lctx lctxTerm wft x := by
-  dsimp [LamWF.interp]; rw [← LamWF.interp_bvarLift]
+  dsimp [LamWF.interp, LamTerm.app_bvarLift_bvar0, app_bvarLift_bvar0, pushLCtx_ofBVar]; rw [← LamWF.interp_bvarLift]
 
 def LamTerm.etaExpand1 (s : LamSort) (t : LamTerm) : LamTerm :=
   .lam s (.app s t.bvarLift (.bvar 0))
 
 theorem LamTerm.maxEVarSucc_etaExpand1 : (etaExpand1 s t).maxEVarSucc = t.maxEVarSucc := by
-  dsimp [maxEVarSucc]; rw [maxEVarSucc_bvarLift]; rw [Nat.max, Nat.max_zero_right]
+  dsimp [etaExpand1, maxEVarSucc]; rw [maxEVarSucc_bvarLift]; rw [Nat.max, Nat.max_zero_right]
 
 def LamWF.etaExpand1 (wft : LamWF ltv ⟨lctx, t, .func argTy resTy⟩) :
   LamWF ltv ⟨lctx, t.etaExpand1 argTy, .func argTy resTy⟩ :=
@@ -470,13 +470,13 @@ theorem LamTerm.maxEVarSucc_extensionalizeEq :
   case base b =>
     cases b <;> try rfl
     case eq s =>
-      dsimp [maxEVarSucc]; rw [maxEVarSucc_extensionalizeEqF]; rfl
+      dsimp [maxEVarSucc, extensionalizeEq]; rw [maxEVarSucc_extensionalizeEqF]; rfl
   case app s fn arg =>
     cases fn <;> try rfl
     case base b =>
       cases b <;> try rfl
       case eq s =>
-        dsimp [maxEVarSucc]; rw [maxEVarSucc_extensionalizeEqF]
+        dsimp [maxEVarSucc, extensionalizeEq]; rw [maxEVarSucc_extensionalizeEqF]
         rw [maxEVarSucc_bvarLift]; apply Nat.max_comm
     case app _ fn' arg' =>
       cases fn' <;> try rfl
@@ -646,7 +646,7 @@ theorem LamEquiv.ofIntensionalizeEq1
   intro lctxTerm
   cases wfEq; case ofApp wfr HFn => cases HFn; case ofApp wfl wfEq =>
     cases wfEq; case ofBase b => cases b; case ofEq =>
-      dsimp [LamWF.interp, LamBaseTerm.LamWF.interp]; apply GLift.down.inj
+      dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, LamWF.mkForallE]; apply GLift.down.inj
       dsimp [forallLiftFn, eqLiftFn]; apply propext (Iff.intro ?mp ?mpr)
       case mp => apply funext
       case mpr => intro h x; apply _root_.congrFun h x
@@ -912,7 +912,7 @@ theorem LamWF.interp_instantiateAt.{u}
 | lctxTy, lctxTerm, wfArg, .ofApp argTy' HFn HArg =>
   let IHFn := LamWF.interp_instantiateAt lval idx lctxTy lctxTerm wfArg HFn
   let IHArg := LamWF.interp_instantiateAt lval idx lctxTy lctxTerm wfArg HArg
-  by dsimp [LamWF.interp]; dsimp at IHFn; dsimp at IHArg; simp [IHFn, IHArg]
+  by dsimp [LamWF.interp, LamTerm.instantiateAt, instantiateAt]; dsimp at IHFn; dsimp at IHArg; simp [IHFn, IHArg]
 
 def LamTerm.instantiate1 := LamTerm.instantiateAt 0
 
@@ -1072,10 +1072,10 @@ theorem LamWF.interp_resolveImport
   | .ofBase b => LamBaseTerm.LamWF.interp_resolveImport lval b
   | .ofBVar n => rfl
   | .ofLam s hwf => by
-    apply funext; intros x; dsimp [interp]
+    apply funext; intros x; dsimp [interp, LamTerm.resolveImport, resolveImport]
     rw [LamWF.interp_resolveImport _ _ hwf]
   | .ofApp s wfFn wfArg => by
-    dsimp [interp];
+    dsimp [interp, LamTerm.resolveImport, resolveImport];
     rw [LamWF.interp_resolveImport _ _ wfFn]
     rw [LamWF.interp_resolveImport _ _ wfArg]
 
@@ -1466,7 +1466,7 @@ theorem LamTerm.maxEVarSucc_eqSymm?
   (heq : LamTerm.eqSymm? t = .some t') : t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app s (.app _ (.base (.eq _)) lhs) _, Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkEq, maxEVarSucc, Nat.max, Nat.max_zero_left]
     apply Nat.max_comm
 
 def LamWF.eqSymm?
@@ -1507,7 +1507,7 @@ theorem LamTerm.maxEVarSucc_neSymm?
   (heq : LamTerm.neSymm? t = .some t') : t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.base .not) (.app s (.app _ (.base (.eq _)) lhs) _), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkEq, mkNot, maxEVarSucc, Nat.max, Nat.max_zero_left]
     apply Nat.max_comm
 
 def LamWF.neSymm?

--- a/Auto/Embedding/LamInference.lean
+++ b/Auto/Embedding/LamInference.lean
@@ -161,7 +161,7 @@ theorem LamThmValid.define {lval : LamValuation.{u}}
     rw [Nat.max_zero_left]; have ⟨_, hlb⟩ := LamThmWFD.ofLamThmWF wft; apply hlb
   case right =>
     exists LamWF.mkEq LamWF.insertEVarAt_eIdx wft'
-    intro lctxTerm; dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, eqLiftFn]
+    intro lctxTerm; dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, LamTerm.mkEq, eqLiftFn]
     apply eq_of_heq; apply HEq.trans (LamWF.interp_insertEVarAt_eIdx _)
     apply LamWF.interp_eVarIrrelevance <;> try rfl
     intro n hn; apply LamValuation.insertEVarAt_eVarIrrelevance
@@ -189,7 +189,7 @@ section Skolemization
     ∃ val, LamThmValid (lval.insertEVarAt (s.mkFuncsRev lctx) val eidx) lctx (.app s p (LamTerm.bvarApps (.etom eidx) lctx 0)) := by
     have ⟨hSucc, ⟨wft, ht⟩⟩ := LamThmValidD.ofLamThmValid vt
     cases wft; case ofApp HArg HFn => cases HFn; case ofBase Hb => cases Hb; case ofExistE =>
-      dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, existLiftFn] at ht;
+      dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, LamTerm.mkExistE, existLiftFn] at ht;
       have ⟨valPre, hvalPre⟩ := choose_spec' ht
       exists LamSort.curryRev valPre; apply LamThmValid.ofLamThmValidD; apply And.intro;
       case left =>

--- a/Auto/Embedding/LamLCtx.lean
+++ b/Auto/Embedding/LamLCtx.lean
@@ -49,7 +49,7 @@ theorem LamValid.intro1H? (H : LamValid lval lctx t)
       let Hp' := LamWF.bvarLiftIdx (s:=s) 0 _ Hp
       let HApp := LamWF.ofApp s Hp' (.ofBVar 0)
       rw [← pushLCtxAt_zero]; exists HApp; intro lctxTerm
-      dsimp [LamWF.interp]
+      dsimp [LamWF.interp, LamTerm.bvarLift]
       have vl' := vl (fun n => lctxTerm (.succ n)) (lctxTerm 0)
       apply Eq.mp _ vl'; apply congrArg; apply congrFun;
       apply Eq.trans (LamWF.interp_bvarLiftIdx lval (idx:=0) lctx
@@ -83,7 +83,7 @@ theorem LamTerm.maxEVarSucc_intro1? (heq : LamTerm.intro1? t = .some (s, t')) :
         dsimp [maxEVarSucc]; rw [Nat.max, Nat.max_def]; simp [Nat.zero_le]
         cases p <;> cases heq <;> try rfl
         case app.refl =>
-          dsimp [maxEVarSucc]; rw [LamTerm.maxEVarSucc_mapBVarAt]; rw [LamTerm.maxEVarSucc_mapBVarAt]
+          dsimp [maxEVarSucc, bvarLift, bvarLiftIdx, bvarLiftsIdx]; rw [LamTerm.maxEVarSucc_mapBVarAt]; dsimp [maxEVarSucc]
           rw [Nat.max, Nat.max_comm, Nat.max_def]; simp [Nat.zero_le]
 
 theorem LamValid.intro1? (H : LamValid lval lctx t)

--- a/Auto/Embedding/LamPrep.lean
+++ b/Auto/Embedding/LamPrep.lean
@@ -81,14 +81,14 @@ theorem LamEquiv.prop_ne_equiv_eq_not
   (wfr : LamWF lval.toLamTyVal ⟨lctx, rhs, .base .prop⟩) :
   LamEquiv lval lctx (.base .prop) (.mkNot (.mkEq (.base .prop) lhs rhs)) (.mkEq (.base .prop) lhs (.mkNot rhs)) := by
   exists LamWF.mkNot (LamWF.mkEq wfl wfr); exists LamWF.mkEq wfl (.mkNot wfr); intro lctxTerm
-  dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, notLift, eqLiftFn]
+  dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, LamWF.mkEq, notLift, eqLiftFn]
   apply GLift.down.inj; apply propext (Iff.intro ?mp ?mpr)
   case mp =>
     intro h; apply GLift.down.inj; apply eq_not_of_ne
     intro h'; apply h; apply GLift.down.inj _ _ h'
   case mpr =>
     intro h h'; have h' := _root_.congrArg GLift.down h'; revert h'
-    apply ne_of_eq_not; dsimp at h; rw [h]; rfl
+    apply ne_of_eq_not; dsimp [LamTerm.mkEq] at h; rw [h]; rfl
 
 /-- (a ≠ b) ↔ (a = (¬ b)) -/
 def LamTerm.prop_ne_equiv_eq_not? (t : LamTerm) : Option LamTerm :=
@@ -101,7 +101,7 @@ theorem LamTerm.maxEVarSucc_prop_ne_equiv_eq_not?
   (heq : prop_ne_equiv_eq_not? t = .some t') : t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.base .not) (.app _ (.app _ (.base (.eq (.base .prop))) lhs) rhs), Eq.refl _ => by
-    dsimp [maxEVarSucc]; simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right]
+    dsimp [mkEq, mkNot, maxEVarSucc]; simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right]
 
 theorem LamEquiv.prop_ne_equiv_eq_not?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -122,7 +122,7 @@ theorem LamGenConv.prop_ne_equiv_eq_not? : LamGenConv lval LamTerm.prop_ne_equiv
 def LamTerm.equalize (t : LamTerm) : LamTerm := .mkEq (.base .prop) t (.base .trueE)
 
 theorem LamTerm.maxEVarSucc_equalize : (LamTerm.equalize t).maxEVarSucc = t.maxEVarSucc := by
-  simp [maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
+  simp [equalize, mkEq, maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
 
 theorem LamEquiv.equalize (wft : LamWF lval.toLamTyVal ⟨lctx, t, .base .prop⟩) :
   LamEquiv lval lctx (.base .prop) t t.equalize := by
@@ -141,7 +141,7 @@ theorem LamTerm.maxEVarSucc_equalize? (heq : equalize? s t = .some t') :
   t'.maxEVarSucc = t.maxEVarSucc := by
   match s, heq with
   | .base .prop, Eq.refl _ =>
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
+    simp [mkEq, maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
 
 theorem LamEquiv.equalize?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, .base .prop⟩)
@@ -296,7 +296,7 @@ theorem LamTerm.maxEVarSucc_eq_false_equiv?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.app _ (.base (.eq _)) lhs) (.base .falseE), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
+    simp [mkNot, maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
 
 theorem LamEquiv.eq_false_equiv?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -396,7 +396,7 @@ def LamTerm.maxEVarSucc_not_eq_true_equiv_eq_false?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.app _ (.base (.eq _)) (.app _ (.base .not) lhs)) (.base .trueE), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkEq, maxEVarSucc, Nat.max, Nat.max_zero_left]
 
 theorem LamEquiv.not_eq_true_equiv_eq_false?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -430,7 +430,7 @@ def LamTerm.maxEVarSucc_not_eq_false_equiv_eq_true?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.app _ (.base (.eq _)) (.app _ (.base .not) lhs)) (.base .falseE), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkEq, maxEVarSucc, Nat.max, Nat.max_zero_left]
 
 theorem LamEquiv.not_eq_false_equiv_eq_true?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -457,7 +457,7 @@ theorem LamEquiv.not_not_equiv
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, .base .prop⟩) :
   LamEquiv lval lctx (.base .prop) (.mkNot (.mkNot t)) t := by
   exists (.mkNot (.mkNot wft)); exists wft; intro lctxTerm
-  dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, notLift]
+  dsimp [LamTerm.mkNot, LamWF.interp, LamBaseTerm.LamWF.interp, notLift]
   apply GLift.down.inj; dsimp
   apply propext (Iff.intro Classical.byContradiction (fun a b => b a))
 
@@ -498,7 +498,7 @@ theorem LamTerm.maxEVarSucc_not_eq_equiv_eq_not?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.app _ (.base (.eq _)) (.app _ (.base .not) lhs)) rhs, Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkEq, mkNot, maxEVarSucc, Nat.max, Nat.max_zero_left]
 
 theorem LamEquiv.not_eq_equiv_eq_not?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -530,7 +530,7 @@ theorem LamTerm.maxEVarSucc_not_eq_not_equiv_eq?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.app _ (.base (.eq _)) (.app _ (.base .not) lhs)) (.app _ (.base .not) rhs), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkEq, maxEVarSucc, Nat.max, Nat.max_zero_left]
 
 theorem LamEquiv.not_eq_not_equiv_eq?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -561,7 +561,7 @@ theorem LamTerm.maxEVarSucc_propext?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.app _ (.base .iff) lhs) rhs, Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkEq, maxEVarSucc, Nat.max, Nat.max_zero_left]
 
 theorem LamEquiv.propext?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -572,7 +572,7 @@ theorem LamEquiv.propext?
     match wft with
     | .ofApp _ (.ofApp _ (.ofBase .ofIff) Hlhs) Hrhs =>
       exists (.mkIff Hlhs Hrhs); exists (.mkEq Hlhs Hrhs); intro lctxTerm
-      dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, iffLift, eqLiftFn]
+      dsimp [LamWF.mkEq, LamWF.interp, LamBaseTerm.LamWF.interp, iffLift, eqLiftFn]
       apply GLift.down.inj; apply propext (Iff.intro ?mp ?mpr)
       case mp =>
         intro h; apply GLift.down.inj; apply propext h
@@ -596,7 +596,7 @@ theorem LamTerm.maxEVarSucc_not_and_equiv_not_or_not?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.base .not) (.app _ (.app _ (.base .and) lhs) rhs), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
+    simp [mkNot, mkOr, maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
 
 theorem LamEquiv.not_and_equiv_not_or_not?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -628,7 +628,7 @@ theorem LamTerm.maxEVarSucc_not_or_equiv_not_and_not?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.base .not) (.app _ (.app _ (.base .or) lhs) rhs), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
+    simp [mkNot, mkAnd, maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right]
 
 theorem LamEquiv.not_or_equiv_not_and_not?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -659,7 +659,7 @@ theorem LamTerm.maxEVarSucc_propeq?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app (.base .prop) (.app _ (.base (.eq _)) lhs) rhs, Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right, Nat.max_eq_left]
+    simp [mkOr, mkNot, mkAnd, maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right, Nat.max_eq_left]
 
 theorem propeq_equiv_eq' {a b : GLift Prop} : (a = b) ↔
   (a.down ∨ ¬ b.down) ∧ (¬ a.down ∨ b.down) := by
@@ -694,7 +694,7 @@ theorem LamTerm.maxEVarSucc_imp_equiv_not_or?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.app _ (.base .imp) lhs) rhs, Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkNot, mkOr, maxEVarSucc, Nat.max, Nat.max_zero_left]
 
 theorem LamEquiv.imp_equiv_not_or?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -726,7 +726,7 @@ theorem LamTerm.maxEVarSucc_not_imp_equiv_and_not?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.base .not) (.app _ (.app _ (.base .imp) lhs) rhs), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left]
+    simp [mkNot, mkAnd, maxEVarSucc, Nat.max, Nat.max_zero_left]
 
 theorem LamEquiv.not_imp_equiv_and_not?
   (wft : LamWF lval.toLamTyVal ⟨lctx, t, s⟩)
@@ -758,7 +758,7 @@ theorem LamTerm.maxEVarSucc_propne?
   t'.maxEVarSucc = t.maxEVarSucc :=
   match t, heq with
   | .app _ (.base .not) (.app (.base .prop) (.app _ (.base (.eq _)) lhs) rhs), Eq.refl _ => by
-    simp [maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right, Nat.max_eq_left]
+    simp [mkNot, mkAnd, mkOr, maxEVarSucc, Nat.max, Nat.max_zero_left, Nat.max_zero_right, Nat.max_eq_left]
 
 theorem propne_equiv_eq' {a b : GLift Prop} : (a ≠ b) ↔
   (a.down ∨ b.down) ∧ (¬ a.down ∨ ¬ b.down) := by

--- a/Auto/Embedding/LamSystem.lean
+++ b/Auto/Embedding/LamSystem.lean
@@ -495,7 +495,7 @@ theorem LamWF.interp_eqForallEH
   {wf : LamWF lval.toLamTyVal ⟨lctx, t, .func argTy (.base .prop)⟩} :
   GLift.down (LamWF.interp lval lctx lctxTerm (.mkForallE wf)) = (∀ x,
     GLift.down (LamWF.interp lval (pushLCtx argTy lctx) (pushLCtxDep x lctxTerm) (.ofApp _ wf.bvarLift .pushLCtx_ofBVar))) := by
-  dsimp [interp, LamBaseTerm.LamWF.interp, forallLiftFn]
+  dsimp [interp, LamBaseTerm.LamWF.interp, LamTerm.mkForallE, mkForallE, forallLiftFn, pushLCtx_ofBVar]
   conv => enter [2, x, 1]; rw [← interp_bvarLift]
 
 theorem LamValid.revert1H (H : LamValid lval (pushLCtx s lctx) (.app s t.bvarLift (.bvar 0))) :
@@ -503,8 +503,8 @@ theorem LamValid.revert1H (H : LamValid lval (pushLCtx s lctx) (.app s t.bvarLif
   have ⟨wfAp, ht⟩ := LamValid.revert1F H
   have .ofApp _ (.ofBase (.ofForallE _)) (.ofLam _ (.ofApp _ wft (.ofBVar _))) := wfAp
   ⟨LamWF.mkForallE (.fromBVarLift _ wft), fun lctxTerm => by
-    dsimp [LamWF.mkForallE, LamWF.interp, LamBaseTerm.LamWF.interp]; intro x
-    dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, forallLiftFn] at ht
+    dsimp [LamWF.mkForallE, LamTerm.mkForallE, LamWF.interp, LamBaseTerm.LamWF.interp]; intro x
+    dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, LamTerm.mkForallEF, forallLiftFn] at ht
     apply Eq.mp _ (ht lctxTerm x); apply congrArg; apply congrFun
     apply Eq.trans (b := LamWF.interp lval (pushLCtx s lctx) (pushLCtxDep x lctxTerm)
       (.bvarLift _ (.fromBVarLift _ wft)))
@@ -521,8 +521,8 @@ theorem LamValid.intro1H (H : LamValid lval lctx (.mkForallE s t)) :
     have ⟨wfF, hF⟩ := H
     have .ofApp _ (.ofBase (.ofForallE _)) wft := wfF
     ⟨.mkForallEF (.ofApp _ (.bvarLift _ wft) .pushLCtx_ofBVar), fun lctxTerm => by
-      dsimp [LamWF.mkForallEF, LamWF.interp, LamBaseTerm.LamWF.interp]; intro x; dsimp
-      dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, forallLiftFn] at hF
+      dsimp [LamWF.mkForallEF, LamWF.interp, LamBaseTerm.LamWF.interp]
+      intro x; dsimp [LamWF.pushLCtx_ofBVar, LamWF.interp]
       apply Eq.mp _ (hF lctxTerm x); apply congrArg; rw [← LamWF.interp_bvarLift]⟩
   )
 
@@ -865,7 +865,7 @@ theorem LamEquiv.forall_congr
   LamEquiv lval lctx (.base .prop) (.mkForallEF argTy fn₁) (.mkForallEF argTy fn₂) := by
   have ⟨wfFn₁, wfFn₂, eqFn⟩ := eFn
   exists LamWF.mkForallEF wfFn₁, LamWF.mkForallEF wfFn₂; intro lctxTerm
-  dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, forallLiftFn]
+  dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, LamTerm.mkForallEF, LamWF.mkForallEF, forallLiftFn]
   apply _root_.congrArg; apply _root_.forall_congr; intro x
   apply _root_.congrArg; apply eqFn
 
@@ -889,7 +889,7 @@ theorem LamEquiv.not_imp_not
   (wf₂ : LamWF lval.toLamTyVal ⟨lctx, t₂, .base .prop⟩) :
   LamEquiv lval lctx (.base .prop) (.mkImp (.mkNot t₁) (.mkNot t₂)) (.mkImp t₂ t₁) := by
   exists (LamWF.mkImp (.mkNot wf₁) (.mkNot wf₂)); exists (LamWF.mkImp wf₂ wf₁); intro lctxTerm
-  dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, impLift, notLift]
+  dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, LamTerm.mkImp, impLift, notLift]
   apply GLift.down.inj; dsimp; apply propext (Iff.intro ?mp ?mpr)
   case mp =>
     intro nin h; apply Classical.byContradiction; intro nh'; apply nin nh' h
@@ -968,7 +968,7 @@ theorem LamWF.interp_funext
   | .ofApp _ (.ofApp _ (.ofBase (.ofEq _)) HLhs) HRhs =>
     match wf₂ with
     | .ofApp _ (.ofApp _ (.ofBase (.ofEq _)) (.ofApp _ HLhs' (.ofBVar _))) (.ofApp _ HRhs' (.ofBVar _)) => by
-      dsimp [interp, LamBaseTerm.LamWF.interp, eqLiftFn]
+      dsimp [interp, LamBaseTerm.LamWF.interp, LamTerm.mkEq, eqLiftFn]
       rcases LamWF.unique HLhs' HLhs.bvarLift with ⟨⟨⟩, ⟨⟩⟩
       rcases LamWF.unique HRhs' HRhs.bvarLift with ⟨⟨⟩, ⟨⟩⟩
       apply propext (Iff.intro ?mp ?mpr)
@@ -990,7 +990,7 @@ theorem LamEquiv.eqFunextF
     let wfAp₂ := LamWF.ofApp _
       (LamWF.bvarLift (s:=argTy) _ wfFn₂) LamWF.pushLCtx_ofBVar
     exists LamWF.mkEq wfFn₁ wfFn₂, LamWF.mkForallEF (LamWF.mkEq wfAp₁ wfAp₂); intro lctxTerm
-    dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, eqLiftFn, forallLiftFn]
+    dsimp +zetaDelta [LamWF.interp, LamBaseTerm.LamWF.interp, LamTerm.mkEq, LamWF.mkEq, LamWF.mkForallEF, LamTerm.mkForallEF, eqLiftFn, forallLiftFn, LamWF.pushLCtx_ofBVar]
     apply _root_.congrArg; apply propext (Iff.intro ?mp ?mpr)
     case mp =>
       intro hinterp h; rw [← LamWF.interp_bvarLift, ← LamWF.interp_bvarLift, hinterp]
@@ -1009,7 +1009,7 @@ theorem LamEquiv.eqFunextH
   | .ofApp _ (.ofApp _ (.ofBase (.ofEq _)) wfFn₁) wfFn₂ =>
     exists LamWF.mkForallEF (.ofApp _ (.ofApp _ (.ofBase (.ofEq _)) wfFn₁) wfFn₂)
     exists LamWF.mkEq (.ofLam _ wfFn₁) (.ofLam _ wfFn₂); intro lctxTerm
-    dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, eqLiftFn, forallLiftFn]
+    dsimp [LamWF.interp, LamBaseTerm.LamWF.interp, LamWF.mkEq, eqLiftFn, forallLiftFn]
     apply GLift.down.inj; dsimp; apply propext (Iff.intro ?mp ?mpr)
     case mp => apply funext
     case mpr => intro h x; apply _root_.congrFun h

--- a/Auto/Lib/Pos.lean
+++ b/Auto/Lib/Pos.lean
@@ -281,7 +281,7 @@ theorem pred_succ_eq (p : Pos) : pred (.succ p) = p := by
 theorem succ_pred_xO (p : Pos) : succ (pred (xO p)) = xO p := by
   induction p <;> try rfl
   case xO p' IH =>
-    dsimp [succ, pred]; dsimp [succ, pred] at IH; rw [IH]
+    dsimp [succ, pred, predXO]; dsimp [succ, pred] at IH; rw [IH]
 
 theorem succ_pred_xI (p : Pos) : succ (pred (xI p)) = xI p := by
   cases p <;> rfl

--- a/Auto/MathlibEmulator/ToExpr.lean
+++ b/Auto/MathlibEmulator/ToExpr.lean
@@ -20,22 +20,22 @@ set_option autoImplicit true
 section override
 namespace Auto
 
-attribute [-instance] Lean.instToExprOption
+attribute [-instance] Lean.instToExprOptionOfToLevel
 
 deriving instance Lean.ToExpr for Option
 
-attribute [-instance] Lean.instToExprList
+attribute [-instance] Lean.instToExprListOfToLevel
 
 deriving instance Lean.ToExpr for List
 
-attribute [-instance] Lean.instToExprArray
+attribute [-instance] Lean.instToExprArrayOfToLevel
 
 instance {α : Type u} [Lean.ToExpr α] [ToLevel.{u}] : Lean.ToExpr (Array α) :=
   let type := Lean.toTypeExpr α
   { toExpr     := fun as => Lean.mkApp2 (Lean.mkConst ``List.toArray [toLevel.{u}]) type (Lean.toExpr as.toList)
     toTypeExpr := Lean.mkApp (Lean.mkConst ``Array [toLevel.{u}]) type }
 
-attribute [-instance] Lean.instToExprProd
+attribute [-instance] Lean.instToExprProdOfToLevel
 
 deriving instance Lean.ToExpr for Prod
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.15.0
+leanprover/lean4:v4.16.0


### PR DESCRIPTION
This PR fixes errors caused by changes to simp in version 4.16.0 of the Lean toolchain. Most of the changes in this PR can probably be avoided by adding the `@[simp]` decorator to the definitions passed to the `dsimp`.