### PR TITLE
chore: upgrade Lean toolchain to v4.17.0

### DIFF
--- a/Auto/Embedding/LamBitVec.lean
+++ b/Auto/Embedding/LamBitVec.lean
@@ -147,7 +147,7 @@ namespace BVLems
     rw [ushiftRight_def]; rcases a with ⟨⟨a, isLt⟩⟩;
     unfold ushiftRight; rw [eq_iff_val_eq]
     dsimp [BitVec.toNat, BitVec.ofNat]
-    rw [Nat.zero_mod, Nat.shiftRight_eq_div_pow]
+    rw [Nat.shiftRight_eq_div_pow]
     apply Iff.intro <;> intro h
     case mp =>
       rw [← Nat.le_iff_div_eq_zero (Nat.two_pow_pos _)]

--- a/Auto/Embedding/LamConv.lean
+++ b/Auto/Embedding/LamConv.lean
@@ -2034,7 +2034,7 @@ section UnsafeOps
       return .none
     if !appFn.isAtom && !appFn.isEtom then
       return .none
-    for ((_, arg), idx) in appargsRev.zipWithIndex do
+    for ((_, arg), idx) in appargsRev.zipIdx do
       let .bvar i := arg
         | return .none
       -- Index within range, `ret[i]` is not assigned before

--- a/Auto/EvaluateAuto/TestAuto.lean
+++ b/Auto/EvaluateAuto/TestAuto.lean
@@ -148,7 +148,7 @@ def runAutoOnConsts (config : EvalAutoConfig) (names : Array Name) : CoreM Unit 
   if let .some fhandle := resultFileHandle? then
     fhandle.putStrLn s!"Total elapsed time: {(← IO.monoMsNow) - globalStartTime} ms"
     fhandle.putStrLn s!"\nSummary:\n"
-    for ((name, result, time, hb), idx) in (names.zip results).zipWithIndex do
+    for ((name, result, time, hb), idx) in (names.zip results).zipIdx do
       fhandle.putStrLn s!"{idx} {result.concise} {time} {hb} {Name.uniqRepr name}"
 
 /--
@@ -280,7 +280,7 @@ def evalAutoAtTheoremsAsync
   let .some batches := Array.groupBySize names config.batchSize
     | throwError "{decl_name%} :: Batch size must be nonzero"
   let mut running := #[]
-  for (batch, idx) in batches.zipWithIndex do
+  for (batch, idx) in batches.zipIdx do
     evaluateFilesHandle.putStrLn (toString idx)
     evaluateFilesHandle.flush
     let logPath := config.resultFolder ++ "/" ++ toString idx

--- a/Auto/EvaluateAuto/TestTranslation.lean
+++ b/Auto/EvaluateAuto/TestTranslation.lean
@@ -43,7 +43,7 @@ def monomorphizedProblemOfAutoLemma (lem : Auto.Lemma) : CoreM (Option (Array Em
   let usedThmNames ← (← Expr.getUsedTheorems lem.proof).filterM (fun name =>
     return !(← Name.onlyLogicInType name))
   let usedThms ← usedThmNames.mapM (fun n => Lemma.ofConst n (.leaf "collected by hammertest"))
-  let monoFn : MetaM (Array Embedding.Lam.LamTerm) := Meta.forallTelescope lem.type fun bs body => do
+  let monoFn : MetaM (Array Embedding.Lam.LamTerm) := Meta.forallTelescope lem.type fun _ body => do
     let negGoal := Expr.app (.const ``Not []) body
     Meta.withLocalDeclD `negGoal negGoal fun _ => do
       let inhLemmas ← Inhabitation.getInhFactsFromLCtx
@@ -82,7 +82,7 @@ def evalMonoSize
   (names : Array Name) (resultFile : String)
   (maxHeartbeats : Nat) : CoreM Unit := do
   let resultHandle ← IO.FS.Handle.mk resultFile .write
-  for (name, idx) in names.zipWithIndex do
+  for (name, idx) in names.zipIdx do
     let rawSize ← rawProblemSizeOfConst name
     let monoSize? ← withCurrHeartbeats <|
       withTheReader Core.Context (fun ctx => {ctx with maxHeartbeats := maxHeartbeats * 1000}) <|
@@ -150,7 +150,7 @@ def evalReduceSize
   NameArray.save names (resultFolder ++ "/names.txt")
   let evaluateNamesHandle ← IO.FS.Handle.mk (resultFolder ++ "/evaluateNames.txt") .write
   let mut running := #[]
-  for (name, idx) in names.zipWithIndex do
+  for (name, idx) in names.zipIdx do
     let evalProc ← runFunctionOnConstsUsingNewLeanProcess
       #[name] ``testReduceWriteResult
       #[toString (repr mode), s!"\"{resultFolder}/{idx}.result\""] memoryLimitKb timeLimitS
@@ -190,7 +190,7 @@ def readEvalReduceSizeResult (resultFolder : String) : CoreM (Array (Name × Exc
       | throwError "{decl_name%} :: Unexpected error"
     if retCode != 0 then
       ref := ref.insert name (.error retCode)
-  for (name, idx) in names.zipWithIndex do
+  for (name, idx) in names.zipIdx do
     let path : System.FilePath := resultFolder ++ s!"/{idx}.result"
     let .ok mdata ← path.metadata.toBaseIO
       | continue

--- a/Auto/Solver/Native.lean
+++ b/Auto/Solver/Native.lean
@@ -43,7 +43,7 @@ def emulateNative (lemmas : Array Lemma) (_ : Array Lemma) : MetaM Expr := do
   let _ ← lemmas.mapM (fun lem => do
     if lem.params.size != 0 then
       throwError "{decl_name%} :: Universe levels parameters are not supported")
-  let descrs := lemmas.zipWithIndex.map (fun (lem, i) => (Name.mkSimple s!"lem{i}", lem.type, .default))
+  let descrs := lemmas.zipIdx.map (fun (lem, i) => (Name.mkSimple s!"lem{i}", lem.type, .default))
   let sty := Expr.mkForallFromBinderDescrs descrs (.const ``False [])
   let sorryExpr := Lean.mkApp2 (.const ``sorryAx [.zero]) sty (.const ``Bool.false [])
   return Lean.mkAppN sorryExpr (lemmas.map (fun lem => lem.proof))

--- a/Auto/Tactic.lean
+++ b/Auto/Tactic.lean
@@ -839,7 +839,7 @@ def buildSelectorForInhabitedType (selCtor : Expr) (argIdx : Nat) : MetaM Expr :
   for (curDatatype, curDatatypeInfo) in mutuallyRecursiveDatatypes do
     for curCtorIdx in [:curDatatypeInfo.ctors.length] do
       if curDatatype == datatype && curCtorIdx == cval.cidx then
-        let decls := selCtorFieldTypes.mapFinIdx fun idx ty => (.str .anonymous ("arg" ++ idx.1.repr), fun prevArgs => pure (ty.instantiate prevArgs))
+        let decls := selCtorFieldTypes.mapFinIdx fun idx ty _ => (.str .anonymous ("arg" ++ idx.repr), fun prevArgs => pure (ty.instantiate prevArgs))
         let nextRecursorArg ←
           Meta.withLocalDeclsD decls fun curCtorFields => do
             let recursiveFieldMotiveDecls ← curCtorFields.filterMapM
@@ -857,7 +857,7 @@ def buildSelectorForInhabitedType (selCtor : Expr) (argIdx : Nat) : MetaM Expr :
         let curCtor ← Meta.mkAppOptM' curCtor (selCtorParams.map some)
         let curCtorType ← Meta.inferType curCtor
         let curCtorFieldTypes := (getForallArgumentTypes curCtorType).toArray
-        let decls := curCtorFieldTypes.mapFinIdx fun idx ty => (.str .anonymous ("arg" ++ idx.1.repr), fun prevArgs => pure (ty.instantiate prevArgs))
+        let decls := curCtorFieldTypes.mapFinIdx fun idx ty _ => (.str .anonymous ("arg" ++ idx.repr), fun prevArgs => pure (ty.instantiate prevArgs))
         let nextRecursorArg ←
           Meta.withLocalDeclsD decls fun curCtorFields => do
             let recursiveFieldMotiveDecls ← curCtorFields.filterMapM
@@ -910,7 +910,7 @@ def buildSelectorForUninhabitedType (selCtor : Expr) (argIdx : Nat) : MetaM Expr
   for (curDatatype, curDatatypeInfo) in mutuallyRecursiveDatatypes do
     for curCtorIdx in [:curDatatypeInfo.ctors.length] do
       if curDatatype == datatype && curCtorIdx == cval.cidx then
-        let decls := selCtorFieldTypes.mapFinIdx fun idx ty => (.str .anonymous ("arg" ++ idx.1.repr), fun prevArgs => pure (ty.instantiate prevArgs))
+        let decls := selCtorFieldTypes.mapFinIdx fun idx ty _ => (.str .anonymous ("arg" ++ idx.repr), fun prevArgs => pure (ty.instantiate prevArgs))
         let nextRecursorArg ←
           Meta.withLocalDeclsD decls fun curCtorFields => do
             let recursiveFieldMotiveDecls ← curCtorFields.filterMapM
@@ -928,7 +928,7 @@ def buildSelectorForUninhabitedType (selCtor : Expr) (argIdx : Nat) : MetaM Expr
         let curCtor ← Meta.mkAppOptM' curCtor (selCtorParams.map some)
         let curCtorType ← Meta.inferType curCtor
         let curCtorFieldTypes := (getForallArgumentTypes curCtorType).toArray
-        let decls := curCtorFieldTypes.mapFinIdx fun idx ty => (.str .anonymous ("arg" ++ idx.1.repr), fun prevArgs => pure (ty.instantiate prevArgs))
+        let decls := curCtorFieldTypes.mapFinIdx fun idx ty _ => (.str .anonymous ("arg" ++ idx.repr), fun prevArgs => pure (ty.instantiate prevArgs))
         let nextRecursorArg ←
           Meta.withLocalDeclsD decls fun curCtorFields => do
             let recursiveFieldMotiveDecls ← curCtorFields.filterMapM

--- a/Auto/Translation/Lam2TH0.lean
+++ b/Auto/Translation/Lam2TH0.lean
@@ -35,7 +35,7 @@ def lam2TH0 (lamVarTy : Array LamSort) (lamEVarTy : Array LamSort) (facts : Arra
   -- Empty type is not inhabited
   if (lamVarTy ++ lamEVarTy).any (fun s => s == .base .empty) then
     return "thf(empty_inhabited, axiom, $false)."
-  let facts ← facts.zipWithIndex.mapM (fun (t, i) =>
+  let facts ← facts.zipIdx.mapM (fun (t, i) =>
     match transLamTerm t with
     | .ok ts => return s!"thf(fact{i}, axiom, {ts})."
     | .error e => throwError e)

--- a/Auto/Translation/LamReif.lean
+++ b/Auto/Translation/LamReif.lean
@@ -126,16 +126,16 @@ def printCheckerStats : ReifM Unit := do
 
 def printValuation : ReifM Unit := do
   let tyVal ← getTyVal
-  for ((e, lvl), idx) in tyVal.zipWithIndex do
+  for ((e, lvl), idx) in tyVal.zipIdx do
     trace[auto.lamReif.printValuation] "Type Atom {idx} := {e} : {Expr.sort lvl}"
   let varVal ← getVarVal
-  for ((e, s), idx) in varVal.zipWithIndex do
+  for ((e, s), idx) in varVal.zipIdx do
     trace[auto.lamReif.printValuation] "Term Atom {idx} : {toString s} := {e}"
   let lamEVarTy ← getLamEVarTy
-  for (s, idx) in lamEVarTy.zipWithIndex do
+  for (s, idx) in lamEVarTy.zipIdx do
     trace[auto.lamReif.printValuation] "Etom {idx} : {toString s}"
   let lamIl ← getLamILTy
-  for (s, idx) in lamIl.zipWithIndex do
+  for (s, idx) in lamIl.zipIdx do
     trace[auto.lamReif.printValuation] "LamILTy {idx} := {s}"
 
 def printProofs : ReifM Unit := do
@@ -837,7 +837,7 @@ section CheckerUtils
       throwError "{decl_name%} :: Length of lctx does not equal size of reorder map"
     let mut ex : Array LamSort := rmap.map (fun _ => .atom 0)
     let mut argBVarIdx : Array Nat := #[]
-    for (s, i) in (Array.mk lctx).zipWithIndex do
+    for (s, i) in (Array.mk lctx).zipIdx do
       let .some i' := rmap[i]?
         | throwError "{decl_name%} :: Does not know where does `.bvar i` map to"
       if i' >= lsize then

--- a/Auto/Translation/LamUtils.lean
+++ b/Auto/Translation/LamUtils.lean
@@ -455,7 +455,6 @@ namespace Lam2D
         (mkApp2 (.const ``instHAppendOfAppend [.zero]) stringc (mkConst ``String.instAppend))),
       (``String.lt, mkApp2 (.const ``LT.lt [.zero]) stringc (mkConst ``String.instLT)),
     ]
-#check LT.lt (α := BitVec 3)
   open LamCstrD in
   def bitVecConstSimpNFList : List (Name × Expr) :=
     let natc := mkConst ``Nat

--- a/Auto/Translation/Monomorphization.lean
+++ b/Auto/Translation/Monomorphization.lean
@@ -282,7 +282,7 @@ def ConstInst.ofExpr? (params : Array Name) (bvars : Array Expr) (e : Expr) : Me
   let mut argsIdx := #[]
   let mut argsInst := #[]
   -- Check that all dependent and instance arguments are instantiated
-  for (arg, idx) in args.zipWithIndex do
+  for (arg, idx) in args.zipIdx do
     headType ← Core.betaReduce headType
     let .forallE _ ty body bi := headType
       | throwError "{decl_name%} :: {headType} is not a `∀`"
@@ -613,9 +613,9 @@ def termLikeDefEqDefEqs (lemmas : Array Lemma) : MetaM (Array Lemma) := do
   let mut ret := #[]
   let mode := auto.mono.termLikeDefEq.mode.get (← getOptions)
   let heartbeats := auto.mono.termLikeDefEq.maxHeartbeats.get (← getOptions)
-  for ((n₁, params₁), idx₁) in nses.zipWithIndex do
+  for ((n₁, params₁), idx₁) in nses.zipIdx do
     if n₁.isLambda || params₁.size != 0 then continue
-    for ((n₂, params₂), idx₂) in nses.zipWithIndex do
+    for ((n₂, params₂), idx₂) in nses.zipIdx do
       if idx₁ >= idx₂ then continue
         let computation := Meta.withNewMCtxDepth <| Meta.withTransparency mode <| Expr.instanceOf? n₂ params₂ n₁
         let computation := Meta.runtimeExToExcept <| Meta.withMaxHeartbeats heartbeats <| computation
@@ -638,7 +638,7 @@ def initializeMonoM (lemmas : Array Lemma) : MonoM Unit := do
     let li ← LemmaInst.ofLemmaHOL lem
     trace[auto.mono.printLemmaInst] "New {li}"
     return li)
-  for (li, idx) in lemmaInsts.zipWithIndex do
+  for (li, idx) in lemmaInsts.zipIdx do
     setActive ((← getActive).enqueue (.inr (li, idx)))
   let lemmaInsts := lemmaInsts.map (fun x => #[x])
   setLisArr lemmaInsts
@@ -681,7 +681,7 @@ def saturate : MonoM Unit := do
       generateCiInstDefEq ci
       let lisArr ← getLisArr
       trace[auto.mono.match] "Matching against {ci}"
-      for (lis, idx) in lisArr.zipWithIndex do
+      for (lis, idx) in lisArr.zipIdx do
         cnt := cnt + 1
         for li in lis do
           let newLis_cnt ← matchCiAndLi ci li idx cnt
@@ -749,7 +749,7 @@ where
     if isTrigger ci.head then
       return
     let cis := ((← getCiMap).toArray.map Prod.snd).flatMap id
-    for (ci', _) in cis.zipWithIndex do
+    for (ci', _) in cis.zipIdx do
       if (← ci.toExpr) != (← ci'.toExpr) && !(isTrigger ci'.head) then
         if let .some (proof, eq, _) ← bidirectionalOfInstanceEq ci ci' then
           let eq := Expr.eraseMData (← Core.betaReduce eq)

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.16.0
+leanprover/lean4:v4.17.0


### PR DESCRIPTION
This PR upgrades the Lean toolchain to v4.17.0. It fixes several warnings, such as unused variables and deprecations of `Array.zipWithIndex`, and addresses errors caused by changes to the function prototype of `Array.mapFinIdx` between v4.16.0 and v4.17.0.
In v4.16.0, the parameter `f` had the type `f : Fin as.size → α → β`, but in v4.17.0, it was changed to `f : (i : Nat) → α → i < as.size → β`.
Additionally, this PR removes an `#check` statement that was only used for debugging.
