### PR TITLE
Bump to Lean v4.20.0-rc3

### DIFF
--- a/Auto/Embedding/LamBase.lean
+++ b/Auto/Embedding/LamBase.lean
@@ -908,7 +908,7 @@ instance : BEq StringConst where
 
 def StringConst.beq_refl {s : StringConst} : (s.beq s) = true := by
   cases s <;> try rfl
-  case strVal s => apply LawfulBEq.rfl (α := String)
+  case strVal s => apply BEq.rfl (α := String)
 
 def StringConst.eq_of_beq_eq_true {s₁ s₂ : StringConst} (H : s₁.beq s₂) : s₁ = s₂ := by
   cases s₁ <;> cases s₂ <;> try (first | contradiction | rfl)
@@ -1258,8 +1258,8 @@ def BitVecConst.beq_refl {b : BitVecConst} : (b.beq b) = true := by
   cases b <;> dsimp [beq] <;> rw [Nat.beq_refl] <;> (try rw [Nat.beq_refl]) <;> (try rfl) <;>
     (try rw [Nat.beq_refl]) <;> (try rfl)
   case bvaOp => rw [BVAOp.beq_refl]; rfl
-  case bvcmp => rw [LawfulBEq.rfl (α := Bool)]; rw [BVCmp.beq_refl]; rfl
-  case bvshOp => rw [LawfulBEq.rfl (α := Bool)]; rw [BVShOp.beq_refl]; rfl
+  case bvcmp => rw [BEq.rfl (α := Bool)]; rw [BVCmp.beq_refl]; rfl
+  case bvshOp => rw [BEq.rfl (α := Bool)]; rw [BVShOp.beq_refl]; rfl
 
 def BitVecConst.eq_of_beq_eq_true {b₁ b₂ : BitVecConst} (H : b₁.beq b₂) : b₁ = b₂ := by
   cases b₁ <;> cases b₂ <;> (try contradiction) <;> (try rw [Nat.eq_of_beq_eq_true H]) <;>
@@ -1757,13 +1757,13 @@ instance : BEq LamBaseTerm where
 
 def LamBaseTerm.beq_refl {b : LamBaseTerm} : (b.beq b) = true := by
   cases b <;> first | rfl | apply LamSort.beq_refl | apply Nat.beq_refl | skip
-  case pcst pc => apply LawfulBEq.rfl (α := PropConst)
-  case bcst bc => apply LawfulBEq.rfl (α := BoolConst)
-  case ncst n => apply LawfulBEq.rfl (α := NatConst)
-  case icst i => apply LawfulBEq.rfl (α := IntConst)
-  case scst s => apply LawfulBEq.rfl (α := StringConst)
-  case bvcst s => apply LawfulBEq.rfl (α := BitVecConst)
-  case ocst o => apply LawfulBEq.rfl (α := OtherConst)
+  case pcst pc => apply BEq.rfl (α := PropConst)
+  case bcst bc => apply BEq.rfl (α := BoolConst)
+  case ncst n => apply BEq.rfl (α := NatConst)
+  case icst i => apply BEq.rfl (α := IntConst)
+  case scst s => apply BEq.rfl (α := StringConst)
+  case bvcst s => apply BEq.rfl (α := BitVecConst)
+  case ocst o => apply BEq.rfl (α := OtherConst)
 
 def LamBaseTerm.eq_of_beq_eq_true {b₁ b₂ : LamBaseTerm} (H : b₁.beq b₂) : b₁ = b₂ := by
   cases b₁ <;> cases b₂ <;> (first | contradiction | rfl | apply congrArg) <;>
@@ -4086,8 +4086,8 @@ theorem LamWF.interp_bvarAppsRev
     rw [List.reverse_cons, pushLCtxs_append_singleton] at wft
     dsimp [LamTerm.bvarAppsRev] at wfAp
     rw [List.reverse_cons, pushLCtxs_append_singleton] at wfAp
-    rw [interp_substLCtxTerm_rec (by rw [List.reverse_cons])
-      (pushLCtxsDep_substxs _ _ _ (List.reverse_cons _ _) HList.reverse_cons)]
+    rw [interp_substLCtxTerm_rec (by simp only [List.reverse_cons])
+      (pushLCtxsDep_substxs _ _ _ (@List.reverse_cons _ _ _) HList.reverse_cons)]
     rw [interp_substLCtxTerm_rec
       (pushLCtxs_append_singleton _ _ _) (pushLCtxsDep_append_singleton _ _ _)]
     rw [LamWF.interp_substWF (wf':=wfAp)]
@@ -4102,7 +4102,7 @@ theorem LamWF.interp_bvarAppsRev
         apply pushLCtxsDep_substxs; rw [List.reverse_cons]; apply HList.reverse_cons
       case h₂ =>
         apply eq_of_heq; apply HEq.trans (LamWF.interp_bvar _)
-        apply HEq.trans (pushLCtxsDep_ge _ (Nat.le_of_eq (List.length_reverse _)))
+        apply HEq.trans (pushLCtxsDep_ge _ (Nat.le_of_eq (@List.length_reverse _ _)))
         rw [List.length_reverse, Nat.sub_self]; rfl
 
 theorem LamWF.interp_eqForallEF

--- a/Auto/Embedding/LamBitVec.lean
+++ b/Auto/Embedding/LamBitVec.lean
@@ -126,7 +126,8 @@ namespace BVLems
       rw [BitVec.ofNat]
       apply ushiftRight_ge_length_eq_zero'; exact h
     case true =>
-      rw [← Int.subNatNat_eq_coe, Int.subNatNat_of_lt (toNat_le _)]
+      have heq : (@HPow.hPow Int Nat Int instHPow 2 n) = ↑(@HPow.hPow Nat Nat Nat instHPow 2 n) := by simp only [Int.natCast_pow, Int.cast_ofNat_Int]
+      rw [heq, ← Int.subNatNat_eq_coe, Int.subNatNat_of_lt (toNat_le _)]
       simp [BitVec.toInt, BitVec.ofInt]
       have hzero : (2 ^ n - BitVec.toNat a - 1) >>> i = 0 := by
         rw [Nat.shiftRight_eq_div_pow]; apply (Nat.le_iff_div_eq_zero (Nat.two_pow_pos _)).mpr
@@ -134,9 +135,9 @@ namespace BVLems
         apply Nat.le_trans (Nat.sub_le _ _) (Nat.pow_le_pow_right (.step .refl) h)
       apply eq_of_val_eq; rw [toNat_ofNatLt, hzero]
       rw [toNat_neg, Int.mod_def', Int.emod]
-      rw [Nat.zero_mod, Int.natAbs_ofNat, Nat.succ_eq_add_one, Nat.zero_add]
+      rw [heq, Nat.zero_mod, Int.natAbs_natCast, Nat.succ_eq_add_one, Nat.zero_add]
       rw [Int.subNatNat_of_sub_eq_zero ((Nat.sub_eq_zero_iff_le).mpr (Nat.two_pow_pos _))]
-      rw [Int.toNat_ofNat, BitVec.toNat_ofNat]
+      rw [Int.toNat_natCast, BitVec.toNat_ofNat]
       cases n <;> try rfl
       case succ n =>
         have hlt : 2 ≤ 2 ^ Nat.succ n := @Nat.pow_le_pow_right 2 (.step .refl) 1 (.succ n) (Nat.succ_le_succ (Nat.zero_le _))
@@ -796,8 +797,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                       (argeq₁ .none) (argeq .none) (argeq (.ofNat n)))
                       (by
                         dsimp [shl_equiv, mkIte, mkNatBinOp, mkBvBinOp, mkBvNatBinOp, maxEVarSucc, pushBVCast]
-                        simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right]
-                        apply maxlem₁)
+                        simp only [Nat.max, Nat.max_zero_left, Nat.max_zero_right, maxlem₁])
                   cases arg
                   case app s''' fn' arg₂ =>
                     have leArg₂ := Nat.le_trans LamTerm.size_app_ge_size_arg leArg
@@ -823,8 +823,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                       (argeq₁ .none) (argeq .none) (argeq (.ofNat n)))
                       (by
                         dsimp [lshr_equiv, mkIte, mkNatBinOp, mkBvBinOp, mkBvNatBinOp, maxEVarSucc, pushBVCast]
-                        simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right]
-                        apply maxlem₁)
+                        simp only [Nat.max, Nat.max_zero_left, Nat.max_zero_right, maxlem₁])
                   cases arg
                   case app s''' fn' arg₂ =>
                     have leArg₂ := Nat.le_trans LamTerm.size_app_ge_size_arg leArg
@@ -850,8 +849,7 @@ theorem LamTerm.maxEVarSucc_pushBVCast : maxEVarSucc (pushBVCast ct t) = maxEVar
                       (argeq₁ .none) (argeq .none) (argeq (.ofNat n)))
                       (by
                         dsimp [ashr_equiv, mkIte, mkEq, mkNatBinOp, mkBvUOp, mkBvBinOp, mkBvNatBinOp, maxEVarSucc, pushBVCast]
-                        simp [Nat.max, Nat.max_zero_left, Nat.max_zero_right]
-                        apply maxlem₂)
+                        simp only [Nat.max, Nat.max_zero_left, Nat.max_zero_right, maxlem₂])
                   cases arg
                   case app s''' fn' arg₂ =>
                     have leArg₂ := Nat.le_trans LamTerm.size_app_ge_size_arg leArg

--- a/Auto/Embedding/LamChecker.lean
+++ b/Auto/Embedding/LamChecker.lean
@@ -52,9 +52,9 @@ theorem REntry.beq_def {l r : REntry} : (l == r) = l.beq r := rfl
 
 theorem REntry.beq_refl {r : REntry} : (r == r) = true := by
   cases r <;> rw [REntry.beq_def] <;> dsimp [beq] <;>
-    (try rw [LawfulBEq.rfl]) <;>
-    (try rw [LawfulBEq.rfl]) <;>
-    (try rw [LawfulBEq.rfl]) <;> rfl
+    (try rw [BEq.rfl]) <;>
+    (try rw [BEq.rfl]) <;>
+    (try rw [BEq.rfl]) <;> rfl
 
 theorem REntry.eq_of_beq_eq_true {l r : REntry} (H : (l == r) = true) : l = r := by
   cases l <;> cases r <;> (try cases H) <;> rw [beq_def] at H <;> dsimp [beq] at H
@@ -105,7 +105,7 @@ theorem RTable.beq_def {l r : RTable} : (l == r) = l.beq r := rfl
 
 theorem RTable.beq_refl {r : RTable} : (r == r) = true := by
   rw [beq_def]; cases r; dsimp [beq]
-  rw [LawfulBEq.rfl, LawfulBEq.rfl, LawfulBEq.rfl]; rfl
+  rw [BEq.rfl, BEq.rfl, BEq.rfl]; rfl
 
 theorem RTable.eq_of_beq_eq_true {l r : RTable} (H : (l == r) = true) : l = r := by
   rw [RTable.beq_def] at H; cases l; cases r; dsimp [beq] at H

--- a/Auto/Embedding/LamConv.lean
+++ b/Auto/Embedding/LamConv.lean
@@ -813,13 +813,12 @@ theorem LamTerm.maxEVarSucc_instantiateAt :
     match hasLooseBVarEq idx fn, hasLooseBVarEq idx arg' with
     | true, true =>
       simp [Nat.max]
-      conv => enter [1, 1]; rw [Nat.max_comm]
+      conv => enter [1, 2]; rw [Nat.max_comm]
       conv => enter [1]; rw [Nat.max_assoc]
-      conv => enter [1, 1]; rw [← Nat.max_assoc]; enter [2]; rw [Nat.max_eq_left .refl]
-      conv => enter [1, 1]; rw [Nat.max_comm]
-      apply Eq.symm; apply Nat.max_assoc
+      conv => enter [1, 1]; rw [Nat.max_assoc]; enter [1]; rw [Nat.max_eq_left .refl]
+      conv => enter [1]; rw [← Nat.max_assoc]; enter [2]; rw [Nat.max_comm]
     | true, false =>
-      simp [Nat.max]; apply Eq.symm; apply Nat.max_assoc
+      simp only [Nat.max, Nat.max_assoc, Bool.or_false]
     | false, true =>
       simp [Nat.max]; rw [Nat.max_assoc, Nat.max_assoc]
       conv => enter [1, 1]; rw [Nat.max_comm]

--- a/Auto/Embedding/LamInhReasoning.lean
+++ b/Auto/Embedding/LamInhReasoning.lean
@@ -10,14 +10,14 @@ namespace Auto.Embedding.Lam
 def Inhabitation.subsumeQuick (s₁ s₂ : LamSort) : Bool :=
   let s₁args := s₁.getArgTys
   let s₁res := s₁.getResTy
-  let s₂args := Std.HashSet.empty.insertMany s₂.getArgTys
+  let s₂args := Std.HashSet.emptyWithCapacity.insertMany s₂.getArgTys
   let s₂res := s₂.getResTy
   s₂args.contains s₂res || (s₁res == s₂res && (
     s₁args.all (fun arg => s₂args.contains arg)
   ))
 
 /-- Run a quick test on whether the inhabitation of `s` is trivial -/
-def Inhabitation.trivialQuick := go Std.HashSet.empty
+def Inhabitation.trivialQuick := go Std.HashSet.emptyWithCapacity
 where go (argTys : Std.HashSet LamSort) (s : LamSort) : Bool :=
   match s with
   | .func argTy resTy =>

--- a/Auto/Embedding/LamPrep.lean
+++ b/Auto/Embedding/LamPrep.lean
@@ -609,7 +609,7 @@ theorem LamEquiv.not_and_equiv_not_or_not?
     | .ofApp _ _ (.ofApp _ (.ofApp _ _ Hlhs) Hrhs) =>
       exists (.mkNot (.mkAnd Hlhs Hrhs)), (.mkOr (.mkNot Hlhs) (.mkNot Hrhs)); intro lctxTerm
       apply GLift.down.inj; apply propext
-      apply Classical.not_and_iff_or_not_not
+      apply Classical.not_and_iff_not_or_not
 
 theorem LamGenConv.not_and_equiv_not_or_not? : LamGenConv lval LamTerm.not_and_equiv_not_or_not? := by
   intro t₁ t₂ heq lctx rty wf

--- a/Auto/EvaluateAuto/CommandAnalysis.lean
+++ b/Auto/EvaluateAuto/CommandAnalysis.lean
@@ -24,7 +24,7 @@ namespace EvalAuto
 
 open Elab Frontend
 
-def processHeaderEnsuring (header : Syntax) (opts : Options) (messages : MessageLog)
+def processHeaderEnsuring (header : TSyntax ``Parser.Module.header) (opts : Options) (messages : MessageLog)
     (inputCtx : Parser.InputContext) (trustLevel : UInt32 := 0) (leakEnv := false) (ensuring : Array Import := #[])
     : IO (Environment × MessageLog) := do
   try
@@ -32,7 +32,7 @@ def processHeaderEnsuring (header : Syntax) (opts : Options) (messages : Message
     pure (env, messages)
   catch e =>
     let env ← mkEmptyEnvironment
-    let spos := header.getPos?.getD 0
+    let spos := header.raw.getPos?.getD 0
     let pos  := inputCtx.fileMap.toPosition spos
     pure (env, messages.add { fileName := inputCtx.fileName, data := toString e, pos := pos })
 

--- a/Auto/EvaluateAuto/TestTactics.lean
+++ b/Auto/EvaluateAuto/TestTactics.lean
@@ -198,13 +198,13 @@ end Tactics
   Note: Use `initSrcSearchPath` to get SearchPath of source files
 -/
 def runTacticsAtConstantDeclaration
-  (name : Name) (searchPath : SearchPath)
+  (name : Name) (_searchPath : SearchPath)
   (tactics : Array (ConstantInfo → TacticM Unit)) : CoreM (Array Result) := do
   if ← isInitializerExecutionEnabled then
     throwError "{decl_name%} :: Running this function with execution of `initialize` code enabled is unsafe"
   let .some modName ← Lean.findModuleOf? name
     | throwError "{decl_name%} :: Cannot find constant {name}"
-  let .some uri ← Server.documentUriFromModule searchPath modName
+  let .some uri ← Server.documentUriFromModule? modName
     | throwError "{decl_name%} :: Cannot find module {modName}"
   let .some path := System.Uri.fileUriToPath? uri
     | throwError "{decl_name%} :: URI {uri} of {modName} is not a file"
@@ -265,7 +265,7 @@ instance : ToString EvalTacticConfig where
   `<i> #[<result> <time> <heartbeats>, ⋯, <result> <time> <heartbeats>] <name>`
 -/
 def evalTacticsAtModule
-  (modName : Name) (searchPath : SearchPath) (filter : ConstantInfo → Bool)
+  (modName : Name) (_searchPath : SearchPath) (filter : ConstantInfo → Bool)
   (config : EvalTacticConfig) : CoreM Unit:= do
   let logFileHandle? : Option IO.FS.Handle ← config.logFile.mapM (fun fname => IO.FS.Handle.mk fname .write)
   let resultFileHandle? : Option IO.FS.Handle ← config.resultFile.mapM (fun fname => IO.FS.Handle.mk fname .write)
@@ -273,7 +273,7 @@ def evalTacticsAtModule
   if let .some fhandle := logFileHandle? then
     fhandle.putStrLn s!"Config = {config}"
     fhandle.putStrLn s!"Start time : {← Std.Time.Timestamp.now}"
-  let .some uri ← Server.documentUriFromModule searchPath modName
+  let .some uri ← Server.documentUriFromModule? modName
     | throwError "{decl_name%} :: Cannot find module {modName}"
   let .some path := System.Uri.fileUriToPath? uri
     | throwError "{decl_name%} :: URI {uri} of {modName} is not a file"

--- a/Auto/EvaluateAuto/TestTranslation.lean
+++ b/Auto/EvaluateAuto/TestTranslation.lean
@@ -178,7 +178,7 @@ where
 -/
 def readEvalReduceSizeResult (resultFolder : String) : CoreM (Array (Name × Except Nat Nat)) := do
   let names ← NameArray.load (resultFolder ++ "/names.txt")
-  let mut ref : Std.HashMap Name (Except Nat Nat) := Std.HashMap.empty
+  let mut ref : Std.HashMap Name (Except Nat Nat) := Std.HashMap.emptyWithCapacity
   let evaluateNames ← IO.FS.readFile (resultFolder ++ "/evaluateNames.txt")
   let evalLines := (evaluateNames.splitOn "\n").filter (fun s => s != "")
   for line in evalLines do

--- a/Auto/IR/SMT.lean
+++ b/Auto/IR/SMT.lean
@@ -455,7 +455,7 @@ section
         "~!@$%^&*_-+=<>.?/" ++
         "ΑαΒβΓγΔδΕεΖζΗηΘθΙιΚκΛλΜμΝνΞξΟοΠπΡρΣσςΤτΥυΦφΧχΨψΩω" ++
         "₀₁₂₃₄₅₆₇₈₉"
-      let allowedSet : Std.HashSet UInt32 := Std.HashSet.insertMany Std.HashSet.empty (List.map Char.val allowedStr.toList)
+      let allowedSet : Std.HashSet UInt32 := Std.HashSet.insertMany Std.HashSet.emptyWithCapacity (List.map Char.val allowedStr.toList)
       c.isAlphanum || allowedSet.contains c.val
 
 

--- a/Auto/LemDB.lean
+++ b/Auto/LemDB.lean
@@ -33,13 +33,13 @@ initialize lemDBExt : LemDBExtension ← registerPersistentEnvExtension {
 }
 
 partial def LemDB.toHashSet : LemDB → AttrM (Std.HashSet Name)
-| .empty => pure Std.HashSet.empty
+| .empty => pure Std.HashSet.emptyWithCapacity
 | .addLemma lem hdb => do
     let hset ← hdb.toHashSet
     return hset.insert lem
 | .compose hdbs => do
     let state := lemDBExt.getState (← getEnv)
-    let mut ret := Std.HashSet.empty
+    let mut ret := Std.HashSet.emptyWithCapacity
     for hdb in hdbs do
       let some hdb := state.get? hdb
         | throwError "{decl_name%} :: Unknown lemma database {hdb}"

--- a/Auto/Lib/BinTree.lean
+++ b/Auto/Lib/BinTree.lean
@@ -27,20 +27,20 @@ private theorem wfAux (n n' : Nat) : n = n' + 2 → n / 2 < n := by
   case hLtK => apply Nat.le_refl
 
 @[irreducible] def inductionOn.{u}
-  {motive : Nat → Sort u} (x : Nat)
+  {motive : Nat → Sort u}
   (ind : ∀ x, motive ((x + 2) / 2) → motive (x + 2))
-  (base₀ : motive 0) (base₁ : motive 1) : motive x :=
+  (base₀ : motive 0) (base₁ : motive 1)  (x : Nat) : motive x :=
   match h : x with
   | 0 => base₀
   | 1 => base₁
-  | x' + 2 => ind x' (inductionOn ((x' + 2) / 2) ind base₀ base₁)
+  | x' + 2 => ind x' (inductionOn ind base₀ base₁ ((x' + 2) / 2) )
 decreasing_by apply wfAux; rfl
 
 @[irreducible] def induction.{u}
   {motive : Nat → Sort u}
   (ind : ∀ x, motive ((x + 2) / 2) → motive (x + 2))
   (base₀ : motive 0) (base₁ : motive 1) : ∀ x, motive x :=
-  fun x => inductionOn x ind base₀ base₁
+  fun x => inductionOn ind base₀ base₁ x
 
 end Bin
 
@@ -96,7 +96,7 @@ theorem eq_of_beq_eq_true [BEq α] (α_eq_of_beq_eq_true : ∀ (x y : α), (x ==
 
 instance [BEq α] [LawfulBEq α] : LawfulBEq (BinTree α) where
   eq_of_beq := eq_of_beq_eq_true (@LawfulBEq.eq_of_beq _ _ _)
-  rfl := beq_refl (@LawfulBEq.rfl _ _ _)
+  rfl := beq_refl (@BEq.rfl _ _ _)
 
 def val? (bt : BinTree α) : Option α :=
   match bt with

--- a/Auto/Lib/Containers.lean
+++ b/Auto/Lib/Containers.lean
@@ -16,7 +16,7 @@ def mergeArray (a1 a2 : Array α) :=
     a1 ++ a2
 
 def tallyArrayHashable [Hashable α] [BEq α] (xs : Array α) : Array (α × Nat) := Id.run <| do
-  let mut ret : Std.HashMap α Nat := Std.HashMap.empty
+  let mut ret : Std.HashMap α Nat := Std.HashMap.emptyWithCapacity
   for x in xs do
     match ret.get? x with
     | .some cnt => ret := ret.insert x (cnt + 1)

--- a/Auto/Lib/ExprExtra.lean
+++ b/Auto/Lib/ExprExtra.lean
@@ -71,7 +71,7 @@ def Expr.collectRawM [Monad m] (p : Expr → m Bool) : Expr → m (Std.HashSet E
 | e@(.proj _ _ b) => do
   let hb ← collectRawM p b
   addp? p e hb
-| e => addp? p e Std.HashSet.empty
+| e => addp? p e Std.HashSet.emptyWithCapacity
 where addp? p e hs := do
   if ← p e then
     return hs.insert e

--- a/Auto/Lib/HList.lean
+++ b/Auto/Lib/HList.lean
@@ -172,7 +172,7 @@ theorem HList.reverseAux_eq_append {xs : HList β as} {ys : HList β bs} :
     case h₂ =>
       congr
       case e_3.h =>
-        dsimp [List.reverseAux]; rw [List.reverseAux_eq_append _ [a]]
+        dsimp [List.reverseAux]; rw [@List.reverseAux_eq_append _ as [a]]
       case e_5 =>
         apply HEq.symm; apply IH
 

--- a/Auto/Lib/LevelExtra.lean
+++ b/Auto/Lib/LevelExtra.lean
@@ -23,7 +23,7 @@ where
   | .max l₁ l₂ => mergeHashSet (go l₁) (go l₂)
   | .imax l₁ l₂ => mergeHashSet (go l₁) (go l₂)
   | .param _ => {}
-  | .mvar id => Std.HashSet.empty.insert id
+  | .mvar id => Std.HashSet.emptyWithCapacity.insert id
 
 def Level.findParam? (p : Name → Bool) : Level → Option Name
 | .zero => .none

--- a/Auto/Lib/NatExtra.lean
+++ b/Auto/Lib/NatExtra.lean
@@ -198,7 +198,7 @@ theorem Nat.le_pow (h : b ≥ 2) : a < b ^ a := by
     rw [Nat.le_sub_iff_add_le lla]; apply h
 
   theorem Nat.testBit_true_iff (a i : Nat) : a.testBit i ↔ 2 ^ i ≤ a % 2 ^ (i + 1) := by
-    rw [Nat.testBit_to_div_mod, decide_eq_true_iff]; apply Iff.intro <;> intro h
+    rw [Nat.testBit_eq_decide_div_mod_eq, decide_eq_true_iff]; apply Iff.intro <;> intro h
     case mp =>
       have ⟨k, hk⟩ := Nat.mod_par h; clear h
       have ⟨r, ⟨er, lr⟩⟩ := Nat.div_par hk (Nat.two_pow_pos _); clear hk; cases er

--- a/Auto/Lib/Pos.lean
+++ b/Auto/Lib/Pos.lean
@@ -50,20 +50,20 @@ def ofNat'WF (n : Nat) :=
 decreasing_by rw [← h]; apply ofNat'WFAux; assumption
 
 @[irreducible] def ofNat'WF.inductionOn.{u}
-  {motive : Nat → Sort u} (x : Nat)
+  {motive : Nat → Sort u}
   (ind : ∀ x, motive ((x + 2) / 2) → motive (x + 2))
-  (base₀ : motive 0) (base₁ : motive 1) : motive x :=
+  (base₀ : motive 0) (base₁ : motive 1) (x : Nat) : motive x :=
   match h : x with
   | 0 => base₀
   | 1 => base₁
-  | x' + 2 => ind x' (inductionOn ((x' + 2) / 2) ind base₀ base₁)
+  | x' + 2 => ind x' (inductionOn ind base₀ base₁ ((x' + 2) / 2))
 decreasing_by apply ofNat'WFAux; rfl
 
 @[irreducible] def ofNat'WF.induction
   {motive : Nat → Sort u}
   (ind : ∀ x, motive ((x + 2) / 2) → motive (x + 2))
   (base₀ : motive 0) (base₁ : motive 1) : ∀ x, motive x :=
-  fun x => ofNat'WF.inductionOn x ind base₀ base₁
+  fun x => ofNat'WF.inductionOn ind base₀ base₁ x
 
 theorem ofNat'WF.succSucc (n : Nat) :
   ofNat'WF (n + 2) =

--- a/Auto/Parser/LeanLex.lean
+++ b/Auto/Parser/LeanLex.lean
@@ -83,16 +83,16 @@ def EREBracket.neg (b : EREBracket) : EREBracket := .minus b (.cc .all)
 
 -- **TODO**: Why does this need `partial`?
 partial def EREBracket.toHashSet : EREBracket → Std.HashSet Char
-  | .cc cty       => Std.HashSet.empty.insertMany (toString cty).toList
-  | .inStr s      => Std.HashSet.empty.insertMany s.toList
+  | .cc cty       => Std.HashSet.emptyWithCapacity.insertMany (toString cty).toList
+  | .inStr s      => Std.HashSet.emptyWithCapacity.insertMany s.toList
   | .plus ⟨bl⟩     => go bl
   | .minus b1 b2  =>
     let hb := b2.toHashSet
     let b1s := b1.toHashSet.toList
-    Std.HashSet.empty.insertMany (b1s.filter (fun x => !hb.contains x))
+    Std.HashSet.emptyWithCapacity.insertMany (b1s.filter (fun x => !hb.contains x))
 where
   go : List EREBracket → Std.HashSet Char
-    | [] => Std.HashSet.empty
+    | [] => Std.HashSet.emptyWithCapacity
     | b :: bl => (go bl).insertMany (toHashSet b)
 
 def EREBracket.toString (e : EREBracket) := String.mk e.toHashSet.toList
@@ -218,7 +218,7 @@ section
 
   def CharGrouping.wf : CharGrouping σ → Bool :=
     fun ⟨ngroup, all, charMap⟩ =>
-      let img := charMap.fold (fun hs _ n => hs.insert n) Std.HashSet.empty
+      let img := charMap.fold (fun hs _ n => hs.insert n) Std.HashSet.emptyWithCapacity
       let surj := (sort img.toList) == List.range ngroup
       let allInCharMap := all.toList.all (fun c => charMap.contains c)
       let sizeEq := all.size == charMap.size
@@ -227,7 +227,7 @@ section
   def CharGrouping.groups : CharGrouping σ → Array (Std.HashSet σ) :=
     fun ⟨ngroup, _, charMap⟩ => Id.run <| do
       let mut arr : Array (Std.HashSet σ) :=
-        Array.mk ((List.range ngroup).map (fun _ => Std.HashSet.empty))
+        Array.mk ((List.range ngroup).map (fun _ => Std.HashSet.emptyWithCapacity))
       for (c, idx) in charMap.toList do
         arr := arr.modify idx (fun hs => hs.insert c)
       return arr
@@ -316,8 +316,8 @@ instance : ToString (ADFA Char) where
 
 def ERE.charGrouping (e : ERE) : CharGrouping Char := Id.run <| do
   let hsets := e.brackets.map EREBracket.toHashSet
-  let mut all := hsets.foldl (fun hs nhs => hs.insertMany nhs) Std.HashSet.empty
-  let mut charMap := all.fold (fun hs c => hs.insert c 0) Std.HashMap.empty
+  let mut all := hsets.foldl (fun hs nhs => hs.insertMany nhs) Std.HashSet.emptyWithCapacity
+  let mut charMap := all.fold (fun hs c => hs.insert c 0) Std.HashMap.emptyWithCapacity
   -- Current number of groups
   let mut curidx := 1
   for hset in hsets do
@@ -341,12 +341,12 @@ def ERE.charGrouping (e : ERE) : CharGrouping Char := Id.run <| do
 private partial def ERE.toNFAAux (cg : CharGrouping Char) : ERE → (NFA Nat)
 | .bracket b     =>
   let bs := toString b
-  let states := bs.foldl (fun hs c => hs.insert (cg.charMap.get! c)) Std.HashSet.empty
+  let states := bs.foldl (fun hs c => hs.insert (cg.charMap.get! c)) Std.HashSet.emptyWithCapacity
   NFA.ofSymbPlus states.toArray
 | .bracketN b    =>
   let bs := toString b
   -- All `utf-8` characters
-  let initHs := Std.HashSet.empty.insertMany ((cg.ngroup + 2) :: List.range cg.ngroup)
+  let initHs := Std.HashSet.emptyWithCapacity.insertMany ((cg.ngroup + 2) :: List.range cg.ngroup)
   let states := bs.foldl (fun hs c => hs.erase (cg.charMap.get! c)) initHs
   NFA.ofSymbPlus states.toArray
 | .startp        => NFA.ofSymb (cg.ngroup)

--- a/Auto/Parser/TPTP.lean
+++ b/Auto/Parser/TPTP.lean
@@ -34,10 +34,10 @@ def tokens := [
 ]
 
 def tokenHashMap : Std.HashSet String :=
-  Std.HashSet.empty.insertMany tokens
+  Std.HashSet.emptyWithCapacity.insertMany tokens
 
 def tokenPrefixes : Std.HashSet String :=
-  Std.HashSet.empty.insertMany $ tokens.flatMap (fun t => Id.run do
+  Std.HashSet.emptyWithCapacity.insertMany $ tokens.flatMap (fun t => Id.run do
     let mut res := []
     let mut pref := ""
     for c in t.data do

--- a/Auto/Tactic.lean
+++ b/Auto/Tactic.lean
@@ -161,7 +161,7 @@ def collectUserLemmas (terms : Array Term) : TacticM (Array Lemma) :=
     return lemmas
 
 def collectHintDBLemmas (names : Array Name) : TacticM (Array Lemma) := do
-  let mut hs : Std.HashSet Name := Std.HashSet.empty
+  let mut hs : Std.HashSet Name := Std.HashSet.emptyWithCapacity
   let mut ret : Array Lemma := #[]
   for name in names do
     let .some db ← findLemDB name

--- a/Auto/Translation/Inhabitation.lean
+++ b/Auto/Translation/Inhabitation.lean
@@ -5,7 +5,7 @@ open Lean
 
 namespace Auto.Inhabitation
 
-private def logicalConsts : Std.HashSet Name := Std.HashSet.empty.insertMany
+private def logicalConsts : Std.HashSet Name := Std.HashSet.emptyWithCapacity.insertMany
   #[``Eq, ``Exists, ``And, ``Or, ``Iff, ``Not]
 
 /--

--- a/Auto/Translation/LamReif.lean
+++ b/Auto/Translation/LamReif.lean
@@ -1478,7 +1478,7 @@ partial def reifTerm (lctx : Std.HashMap FVarId Nat) : Expr → ReifM LamTerm
 | e => processTermExpr lctx e
 
 def reifTermCheckType (e : Expr) : ReifM (LamSort × LamTerm) := do
-  let t ← reifTerm .empty e
+  let t ← reifTerm .emptyWithCapacity e
   let ltv ← getLamTyValAtMeta
   let .some s := t.lamCheck? ltv Embedding.Lam.dfLCtxTy
     | throwError "{decl_name%} :: LamTerm {t} is not type correct"

--- a/Auto/Translation/LamUtils.lean
+++ b/Auto/Translation/LamUtils.lean
@@ -49,20 +49,20 @@ namespace LamExportUtils
     "constants should have been eliminated"
 
   def collectLamSortAtoms : LamSort → Std.HashSet Nat
-  | .atom n => Std.HashSet.empty.insert n
-  | .base _ => Std.HashSet.empty
+  | .atom n => Std.HashSet.emptyWithCapacity.insert n
+  | .base _ => Std.HashSet.emptyWithCapacity
   | .func a b => (collectLamSortAtoms a).insertMany (collectLamSortAtoms b)
 
   def collectLamSortsAtoms (ss : Array LamSort) : Std.HashSet Nat :=
-    ss.foldl (fun hs s => hs.insertMany (collectLamSortAtoms s)) Std.HashSet.empty
+    ss.foldl (fun hs s => hs.insertMany (collectLamSortAtoms s)) Std.HashSet.emptyWithCapacity
 
   def collectLamSortBitVecLengths : LamSort → Std.HashSet Nat
-  | .base (.bv n) => Std.HashSet.empty.insert n
+  | .base (.bv n) => Std.HashSet.emptyWithCapacity.insert n
   | .func a b => (collectLamSortBitVecLengths a).insertMany (collectLamSortBitVecLengths b)
-  | _ => Std.HashSet.empty
+  | _ => Std.HashSet.emptyWithCapacity
 
   def collectLamSortsBitVecLengths (ss : Array LamSort) : Std.HashSet Nat :=
-    ss.foldl (fun hs s => hs.insertMany (collectLamSortBitVecLengths s)) Std.HashSet.empty
+    ss.foldl (fun hs s => hs.insertMany (collectLamSortBitVecLengths s)) Std.HashSet.emptyWithCapacity
 
   /-- Collect type atoms in a LamBaseTerm -/
   def collectLamBaseTermAtoms (b : LamBaseTerm) : CoreM (Std.HashSet Nat) := do
@@ -80,7 +80,7 @@ namespace LamExportUtils
     if let .some s := s? then
       return collectLamSortAtoms s
     else
-      return Std.HashSet.empty
+      return Std.HashSet.emptyWithCapacity
 
   /--
     The first hashset is the type atoms
@@ -96,14 +96,14 @@ namespace LamExportUtils
   | .atom n => do
     let .some s := lamVarTy[n]?
       | throwError "{decl_name%} :: Unknown term atom {n}"
-    return (collectLamSortAtoms s, Std.HashSet.empty.insert n, Std.HashSet.empty)
+    return (collectLamSortAtoms s, Std.HashSet.emptyWithCapacity.insert n, Std.HashSet.emptyWithCapacity)
   | .etom n => do
     let .some s := lamEVarTy[n]?
       | throwError "{decl_name%} :: Unknown etom {n}"
-    return (collectLamSortAtoms s, Std.HashSet.empty, Std.HashSet.empty.insert n)
+    return (collectLamSortAtoms s, Std.HashSet.emptyWithCapacity, Std.HashSet.emptyWithCapacity.insert n)
   | .base b => do
-    return (← collectLamBaseTermAtoms b, Std.HashSet.empty, Std.HashSet.empty)
-  | .bvar _ => pure (Std.HashSet.empty, Std.HashSet.empty, Std.HashSet.empty)
+    return (← collectLamBaseTermAtoms b, Std.HashSet.emptyWithCapacity, Std.HashSet.emptyWithCapacity)
+  | .bvar _ => pure (Std.HashSet.emptyWithCapacity, Std.HashSet.emptyWithCapacity, Std.HashSet.emptyWithCapacity)
   | .lam s t => do
     let (typeHs, termHs, etomHs) ← collectLamTermAtoms lamVarTy lamEVarTy t
     let sHs := collectLamSortAtoms s
@@ -120,52 +120,52 @@ namespace LamExportUtils
     ts.foldlM (fun (tyHs, aHs, eHs) t => do
       let (tyHs', aHs', eHs') ← collectLamTermAtoms lamVarTy lamEVarTy t
       return (mergeHashSet tyHs tyHs', mergeHashSet aHs aHs', mergeHashSet eHs eHs'))
-      (Std.HashSet.empty, Std.HashSet.empty, Std.HashSet.empty)
+      (Std.HashSet.emptyWithCapacity, Std.HashSet.emptyWithCapacity, Std.HashSet.emptyWithCapacity)
 
   def collectLamTermNatConsts : LamTerm → Std.HashSet NatConst
-  | .base (.ncst nc) => Std.HashSet.empty.insert nc
+  | .base (.ncst nc) => Std.HashSet.emptyWithCapacity.insert nc
   | .lam _ body => collectLamTermNatConsts body
   | .app _ fn arg => mergeHashSet (collectLamTermNatConsts fn) (collectLamTermNatConsts arg)
-  | _ => Std.HashSet.empty
+  | _ => Std.HashSet.emptyWithCapacity
 
   def collectLamTermsNatConsts (ts : Array LamTerm) : Std.HashSet NatConst :=
-    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermNatConsts t)) Std.HashSet.empty
+    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermNatConsts t)) Std.HashSet.emptyWithCapacity
 
   def collectLamTermIntConsts : LamTerm → Std.HashSet IntConst
-  | .base (.icst ic) => Std.HashSet.empty.insert ic
+  | .base (.icst ic) => Std.HashSet.emptyWithCapacity.insert ic
   | .lam _ body => collectLamTermIntConsts body
   | .app _ fn arg => mergeHashSet (collectLamTermIntConsts fn) (collectLamTermIntConsts arg)
-  | _ => Std.HashSet.empty
+  | _ => Std.HashSet.emptyWithCapacity
 
   def collectLamTermsIntConsts (ts : Array LamTerm) : Std.HashSet IntConst :=
-    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermIntConsts t)) Std.HashSet.empty
+    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermIntConsts t)) Std.HashSet.emptyWithCapacity
 
   def collectLamTermStringConsts : LamTerm → Std.HashSet StringConst
-  | .base (.scst sc) => Std.HashSet.empty.insert sc
+  | .base (.scst sc) => Std.HashSet.emptyWithCapacity.insert sc
   | .lam _ body => collectLamTermStringConsts body
   | .app _ fn arg => mergeHashSet (collectLamTermStringConsts fn) (collectLamTermStringConsts arg)
-  | _ => Std.HashSet.empty
+  | _ => Std.HashSet.emptyWithCapacity
 
   def collectLamTermsStringConsts (ts : Array LamTerm) : Std.HashSet StringConst :=
-    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermStringConsts t)) Std.HashSet.empty
+    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermStringConsts t)) Std.HashSet.emptyWithCapacity
 
   def collectLamTermBitvecs : LamTerm → Std.HashSet BitVecConst
-  | .base (.bvcst bvc) => Std.HashSet.empty.insert bvc
+  | .base (.bvcst bvc) => Std.HashSet.emptyWithCapacity.insert bvc
   | .lam _ body => collectLamTermBitvecs body
   | .app _ fn arg => mergeHashSet (collectLamTermBitvecs fn) (collectLamTermBitvecs arg)
-  | _ => Std.HashSet.empty
+  | _ => Std.HashSet.emptyWithCapacity
 
   def collectLamTermsBitvecs (ts : Array LamTerm) : Std.HashSet BitVecConst :=
-    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermBitvecs t)) Std.HashSet.empty
+    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermBitvecs t)) Std.HashSet.emptyWithCapacity
 
   def collectLamTermIteSorts : LamTerm → Std.HashSet LamSort
-  | .base (.ite s) => Std.HashSet.empty.insert s
+  | .base (.ite s) => Std.HashSet.emptyWithCapacity.insert s
   | .lam _ body => collectLamTermIteSorts body
   | .app _ fn arg => mergeHashSet (collectLamTermIteSorts fn) (collectLamTermIteSorts arg)
-  | _ => Std.HashSet.empty
+  | _ => Std.HashSet.emptyWithCapacity
 
   def collectLamTermsIteSorts (ts : Array LamTerm) : Std.HashSet LamSort :=
-    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermIteSorts t)) Std.HashSet.empty
+    ts.foldl (fun hs t => mergeHashSet hs (collectLamTermIteSorts t)) Std.HashSet.emptyWithCapacity
 
 end LamExportUtils
 

--- a/Auto/Translation/Monomorphization.lean
+++ b/Auto/Translation/Monomorphization.lean
@@ -260,8 +260,8 @@ def ConstInst.matchExpr (e : Expr) (ci : ConstInst) : MetaM Bool := do
   · The expression does not contain level parameters in `params`
 -/
 def ConstInst.ofExpr? (params : Array Name) (bvars : Array Expr) (e : Expr) : MetaM (Option ConstInst) := do
-  let paramSet := Std.HashSet.empty.insertMany params
-  let bvarSet := Std.HashSet.empty.insertMany bvars
+  let paramSet := Std.HashSet.emptyWithCapacity.insertMany params
+  let bvarSet := Std.HashSet.emptyWithCapacity.insertMany bvars
   let fn := e.getAppFn
   -- If the head contains bound variable, then this is not
   --   a valid instance
@@ -414,7 +414,7 @@ private partial def MLemmaInst.matchConstInst (ci : ConstInst) (mi : MLemmaInst)
 | .bvar _ => throwError "{decl_name%} :: Loose bound variable"
 | e@(.app ..) => do
   let args := e.getAppArgs
-  let mut ret := Std.HashSet.empty
+  let mut ret := Std.HashSet.emptyWithCapacity
   for arg in args do
     ret := mergeHashSet ret (← MLemmaInst.matchConstInst ci mi arg)
   let s ← saveState
@@ -437,14 +437,14 @@ private partial def MLemmaInst.matchConstInst (ci : ConstInst) (mi : MLemmaInst)
 | .letE .. => throwError "{decl_name%} :: Let-expressions should have been reduced"
 | .mdata .. => throwError "{decl_name%} :: mdata should have been consumed"
 | .proj .. => throwError "{decl_name%} :: Projections should have been turned into ordinary expressions"
-| _ => return Std.HashSet.empty
+| _ => return Std.HashSet.emptyWithCapacity
 
 /-- Given a LemmaInst `li` and a ConstInst `ci`, try to match all subexpressions of `li` against `ci` -/
 def LemmaInst.matchConstInst (ci : ConstInst) (li : LemmaInst) : MetaM (Std.HashSet LemmaInst) :=
   Meta.withNewMCtxDepth do
     let (lmvars, mvars, mi) ← MLemmaInst.ofLemmaInst li
     if lmvars.size == 0 && mvars.size == 0 then
-      return Std.HashSet.empty
+      return Std.HashSet.emptyWithCapacity
     -- Match with `b` in `∀ (x₁ : α₁) ⋯ (xₙ : αₙ). b := li.type`
     let mut ret ← MLemmaInst.matchConstInst ci mi mi.type
     -- Match with `α₁ ⋯ αₙ` in `∀ (x₁ : α₁) ⋯ (xₙ : αₙ). b := li.type`
@@ -482,7 +482,7 @@ where
         | _ => false
       if hol && (← getMode) == .fol then
         return false
-      let fvarSet := Std.HashSet.empty.insertMany fvars
+      let fvarSet := Std.HashSet.emptyWithCapacity.insertMany fvars
       if ty.hasAnyFVar fvarSet.contains then
         return false
       leadingForallQuasiMonomorphicAux (fvars.push xid)  bodyi
@@ -819,11 +819,11 @@ namespace FVarRep
 
   def getBfvarSet : FVarRepM (Std.HashSet FVarId) := do
     let bfvars ← getBfvars
-    return Std.HashSet.empty.insertMany bfvars
+    return Std.HashSet.emptyWithCapacity.insertMany bfvars
 
   def getFfvarSet : FVarRepM (Std.HashSet FVarId) := do
     let ffvars ← getFfvars
-    return Std.HashSet.empty.insertMany ffvars
+    return Std.HashSet.emptyWithCapacity.insertMany ffvars
 
   /-- Similar to `Monomorphization.processConstInst` -/
   def processConstInst (ci : ConstInst) : FVarRepM Unit := do

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.18.0
+leanprover/lean4:v4.20.0-rc3


### PR DESCRIPTION
`lean-auto` [currently doesn't work on macOS 15.4](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Linking.20issues.20when.20bumping.20.60lean-cvc5.60.20to.20v4.2E20.2E0-rc2/with/516163745) due to a bug in Lean that has been [fixed](https://github.com/leanprover/lean4/pull/8236) in `v4.20.0-rc3`.

This is the kind of error you see:

```
✖ [201/234] Building Auto.EvaluateAuto.EnvAnalysis
trace: .> LEAN_PATH=././.lake/build/lib/lean /Users/dranov/.elan/toolchains/leanprover--lean4---v4.18.0/bin/lean ././././Auto/EvaluateAuto/EnvAnalysis.lean -R ./././. -o ././.lake/build/lib/lean/Auto/EvaluateAuto/EnvAnalysis.olean -i ././.lake/build/lib/lean/Auto/EvaluateAuto/EnvAnalysis.ilean -c ././.lake/build/ir/Auto/EvaluateAuto/EnvAnalysis.c --plugin ././.lake/build/lib/lean/Auto_EvaluateAuto_NameArr.dylib --json
info: stderr:
libc++abi: terminating due to uncaught exception of type lean::exception: error loading library, dlopen(/Users/dranov/src/lean-auto-upstream/.lake/build/lib/lean/Auto_EvaluateAuto_NameArr.dylib, 0x0009): tried: '/Users/dranov/src/lean-auto-upstream/.lake/build/lib/lean/Auto_EvaluateAuto_NameArr.dylib' (__DATA_CONST segment missing SG_READ_ONLY flag), '/System/Volumes/Preboot/Cryptexes/OS/Users/dranov/src/lean-auto-upstream/.lake/build/lib/lean/Auto_EvaluateAuto_NameArr.dylib' (no such file), '/Users/dranov/src/lean-auto-upstream/.lake/build/lib/lean/Auto_EvaluateAuto_NameArr.dylib' (__DATA_CONST segment missing SG_READ_ONLY flag)
```

This PR bumps the toolchain to `v4.20.0-rc3` so that users running macOS 15.4 can still build `lean-auto`.