### PR TITLE
update lean toolchain to v4.29.0

### DIFF
--- a/Auto/Embedding/LamBase.lean
+++ b/Auto/Embedding/LamBase.lean
@@ -3935,17 +3935,17 @@ def LamWF.ofLamCheck? {ltv : LamTyVal} :
       rw [LamSort.eq_of_beq_eq_true h₂] at h₁
       apply LamWF.ofLamCheck? h₁
 
-noncomputable def LamWF.interp.{u} (lval : LamValuation.{u}) :
-  (lctxTy : Nat → LamSort) → (lctxTerm : ∀ n, (lctxTy n).interp lval.tyVal) →
+noncomputable def LamWF.interp.{u} (lval : LamValuation.{u})
+  (lctxTy : Nat → LamSort) (lctxTerm : ∀ n, (lctxTy n).interp lval.tyVal) :
   (lwf : LamWF lval.toLamTyVal ⟨lctxTy, t, rty⟩) → rty.interp lval.tyVal
-| _,      _       , .ofAtom n => lval.varVal n
-| _,      _       , .ofEtom n => lval.eVarVal n
-| _,      _       , .ofBase H => LamBaseTerm.LamWF.interp lval H
-| lctxTy, lctxTerm, .ofBVar n => lctxTerm n
-| lctxTy, lctxTerm, @LamWF.ofLam _ _ argTy _ body H =>
+| .ofAtom n => lval.varVal n
+| .ofEtom n => lval.eVarVal n
+| .ofBase H => LamBaseTerm.LamWF.interp lval H
+| .ofBVar n => lctxTerm n
+| @ofLam _ _ argTy _ body H =>
   fun (x : argTy.interp lval.tyVal) =>
     LamWF.interp lval (pushLCtx argTy lctxTy) (pushLCtxDep (rty:=lctxTy) x lctxTerm) H
-| lctxTy, lctxTerm, .ofApp _ HFn HArg =>
+| .ofApp _ HFn HArg =>
   let mfn := LamWF.interp lval lctxTy lctxTerm HFn
   let marg := LamWF.interp lval lctxTy lctxTerm HArg
   mfn marg

--- a/Auto/Embedding/LamBase.lean
+++ b/Auto/Embedding/LamBase.lean
@@ -4092,7 +4092,7 @@ theorem LamWF.interp_bvarAppsRev
       (pushLCtxsDep_substxs _ _ _ List.reverse_cons HList.reverse_cons)]
     rw [interp_substLCtxTerm_rec
       (pushLCtxs_append_singleton _ _ _) (pushLCtxsDep_append_singleton _ _ _)]
-    rw [LamWF.interp_substWF (wf':=wfAp)]
+    rw [LamWF.interp_substWF (t:=t.bvarAppsRev (lty :: lctxTy)) (wf':=wfAp)]
     apply IH (LamWF.ofApp _ wft LamWF.bvarAppsRev_Aux)
     simp only[interp]; apply HEq.trans (b:=LamSort.curry valPre lterm) <;> try rfl
     case h₁ =>
@@ -4133,7 +4133,9 @@ theorem LamWF.interp_eqForallEFN'
       enter [2]; rw [IsomType.eqForall HList.cons_IsomType]; rw [Prod.eqForall']
       unfold HList.cons_IsomType; dsimp; enter [xs, x]
     apply forall_congr; intro xs
-    rw [interp_app, interp_base, interp_lam, eq_of_heq (LamBaseTerm.interp_equiv _ _)]
+    conv => lhs; rw [interp_substWF
+      (wf':=LamWF.mkForallEF (LamWF.fromMkForallEF (LamWF.fromMkForallEFN' wfMkF)))]
+    rw [interp_eqForallEF]
     apply forall_congr; intro x
     apply congrArg; apply eq_of_heq; apply interp_heq <;> try rfl
     case HLCtxTyEq => rw [pushLCtxs_cons]
@@ -4200,7 +4202,7 @@ theorem LamWF.interp_insertEVarAt_eIdx
   let lval' := {lval with lamEVarTy := replaceAt ty pos lamEVarTy',
                           eVarVal := replaceAtDep val pos eVarVal'}
   HEq (lwf.interp lval' lctxTy lctxTerm) val := by
-  cases lwf; simp only [interp, replaceAt, replaceAtDep]
+  cases lwf; simp only [interp, replaceAtDep]; simp only [replaceAt]
   rw [Nat.beq_refl]; rfl
 
 theorem LamWF.interp_eVarIrrelevance

--- a/Auto/Embedding/LamChecker.lean
+++ b/Auto/Embedding/LamChecker.lean
@@ -159,7 +159,7 @@ section CVal
     ∀ (n : Nat), ILLift.{u} ((lamILTy n).interp tyVal) :=
     fun n => ILLift.default ((lamILTy n).interp tyVal)
 
-  def CVal.toLamTyVal (cv : CVal.{u} levt) : LamTyVal :=
+  noncomputable def CVal.toLamTyVal (cv : CVal.{u} levt) : LamTyVal :=
     ⟨fun n => ((cv.var.get? n).getD ⟨.base .prop, GLift.up False⟩).fst,
      fun n => ((cv.il.get? n).getD ⟨.base .prop, ILLift.default _⟩).fst,
      fun n => (levt.get? n).getD (.base .prop)⟩
@@ -173,15 +173,15 @@ section CVal
   def CPVal.toLamVarTy (cpv : CPVal.{u}) : Nat → LamSort :=
     fun n => ((cpv.var.get? n).getD ⟨.base .prop, GLift.up False⟩).fst
 
-  def CPVal.toLamILTy (cpv : CPVal.{u}) : Nat → LamSort :=
+  noncomputable def CPVal.toLamILTy (cpv : CPVal.{u}) : Nat → LamSort :=
     fun n => ((cpv.il.get? n).getD ⟨.base .prop, ILLift.default _⟩).fst
 
-  def CPVal.toLamTyValWithLamEVarTy (cpv : CPVal.{u}) (levt : Nat → LamSort) : LamTyVal :=
+  noncomputable def CPVal.toLamTyValWithLamEVarTy (cpv : CPVal.{u}) (levt : Nat → LamSort) : LamTyVal :=
     ⟨fun n => ((cpv.var.get? n).getD ⟨.base .prop, GLift.up False⟩).fst,
      fun n => ((cpv.il.get? n).getD ⟨.base .prop, ILLift.default _⟩).fst,
      levt⟩
 
-  def CPVal.toLamTyValEraseEtom (cpv : CPVal.{u}) : LamTyVal :=
+  noncomputable def CPVal.toLamTyValEraseEtom (cpv : CPVal.{u}) : LamTyVal :=
     ⟨fun n => ((cpv.var.get? n).getD ⟨.base .prop, GLift.up False⟩).fst,
      fun n => ((cpv.il.get? n).getD ⟨.base .prop, ILLift.default _⟩).fst,
      fun _ => .base .prop⟩
@@ -422,7 +422,7 @@ abbrev importTablePSigmaβ (cpv : CPVal.{u}) (ie : ImportEntry) :=
 abbrev importTablePSigmaMk (cpv : CPVal.{u}) :=
   @PSigma.mk ImportEntry (importTablePSigmaβ cpv)
 
-def ImportTable.importFacts (it : ImportTable cpv) : BinTree REntry :=
+noncomputable def ImportTable.importFacts (it : ImportTable cpv) : BinTree REntry :=
   it.mapOpt (fun ⟨ie, _⟩ =>
     match ie with
     | .valid p =>
@@ -2345,7 +2345,7 @@ theorem ChkSteps.run_correct
   dsimp [ChkSteps.run]; apply BinTree.foldl_inv (fun (r : RTable) => ∃ eV', RTable.inv r ⟨cpv, eV'⟩) inv
   intro r' (c, n) inv'; exact ChkStep.run_correct r' cpv inv' c n
 
-def ChkSteps.runFromBeginning (cpv : CPVal.{u}) (it : ImportTable cpv) (cs : ChkSteps) :=
+noncomputable def ChkSteps.runFromBeginning (cpv : CPVal.{u}) (it : ImportTable cpv) (cs : ChkSteps) :=
   ChkSteps.run cpv.toLamVarTy cpv.toLamILTy ⟨it.importFacts, 0, .leaf⟩ cs
 
 /--

--- a/Auto/Embedding/LamSystem.lean
+++ b/Auto/Embedding/LamSystem.lean
@@ -522,7 +522,7 @@ theorem LamValid.intro1H (H : LamValid lval lctx (.mkForallE s t)) :
     have ⟨wfF, hF⟩ := H
     have .ofApp _ (.ofBase (.ofForallE _)) wft := wfF
     ⟨.mkForallEF (.ofApp _ (.bvarLift _ wft) .pushLCtx_ofBVar), fun lctxTerm => by
-      simp only [LamWF.mkForallEF, LamWF.interp, LamBaseTerm.LamWF.interp]
+      simp only [LamWF.mkForallEF]
       intro x; simp only [LamWF.pushLCtx_ofBVar, LamWF.interp, eq_mp_eq_cast, cast_eq, id_eq]
       apply Eq.mp _ (hF lctxTerm x); apply congrArg; rw [← LamWF.interp_bvarLift]⟩
   )

--- a/Auto/IR/SMT.lean
+++ b/Auto/IR/SMT.lean
@@ -410,7 +410,7 @@ section
 
   @[always_inline]
   instance : Monad (TransM ω) :=
-    let i := inferInstanceAs (Monad (TransM ω));
+    let i : Monad (TransM ω) := inferInstance;
     { pure := i.pure, bind := i.bind }
 
   instance : Inhabited (TransM ω α) where

--- a/Auto/Lib/BinTree.lean
+++ b/Auto/Lib/BinTree.lean
@@ -20,12 +20,9 @@ open ToExprExtra
 
 namespace Bin
 
-private theorem wfAux (n n' : Nat) : n = n' + 2 → n / 2 < n := by
-  intro H; apply Nat.div_lt_self
-  case hLtN =>
-    cases n;
-    contradiction;
-    apply Nat.succ_le_succ; apply Nat.zero_le
+private theorem wfAux (n : Nat) : (n + 2).div 2 < n + 2 := by
+  apply Nat.div_lt_self
+  case hLtN => apply Nat.succ_le_succ; apply Nat.zero_le
   case hLtK => apply Nat.le_refl
 
 def inductionOn.{u}
@@ -36,7 +33,6 @@ def inductionOn.{u}
   | 0 => base₀
   | 1 => base₁
   | x' + 2 => ind x' (inductionOn ((x' + 2) / 2) ind base₀ base₁)
-decreasing_by apply wfAux; rfl
 
 @[irreducible] def induction.{u}
   {motive : Nat → Sort u}
@@ -118,16 +114,16 @@ def right! (bt : BinTree α) :=
   | .leaf => leaf
   | .node _ _ r => r
 
+attribute [local simp] Bin.wfAux
+
 def get?'WF (bt : BinTree α) (n : Nat) : Option α :=
-  match h : n with
+  match _ : n with
   | 0 => .none
   | 1 => bt.val?
   | _ + 2 =>
     match Nat.mod n 2 with
     | 0 => get?'WF bt.left! (Nat.div n 2)
     | _ + 1 => get?'WF bt.right! (Nat.div n 2)
-termination_by n
-decreasing_by all_goals { rw [← h]; apply Bin.wfAux; assumption }
 
 theorem get?'WF.succSucc (bt : BinTree α) (n : Nat) :
   get?'WF bt (n + 2) =
@@ -200,7 +196,7 @@ theorem get?'_leaf (n : Nat) : @get?' α .leaf n = .none := by
     cases (n + 2) % 2 <;> exact IH
 
 def insert'WF (bt : BinTree α) (n : Nat) (x : α) : BinTree α :=
-  match h : n with
+  match _ : n with
   | 0 => bt
   | 1 =>
     match bt with
@@ -216,8 +212,6 @@ def insert'WF (bt : BinTree α) (n : Nat) (x : α) : BinTree α :=
       match bt with
       | .leaf => .node .leaf .none (insert'WF .leaf (Nat.div n 2) x)
       | .node l v r => .node l v (insert'WF r (Nat.div n 2) x)
-termination_by n
-decreasing_by all_goals { rw [← h]; apply Bin.wfAux; assumption }
 
 theorem insert'WF.succSucc (bt : BinTree α) (n : Nat) (x : α) :
   insert'WF bt (n + 2) x =

--- a/Auto/Lib/MetaState.lean
+++ b/Auto/Lib/MetaState.lean
@@ -14,7 +14,7 @@ structure SavedState where
 abbrev MetaStateM := StateRefT State CoreM
 
 @[always_inline]
-instance : Monad MetaStateM := let i := inferInstanceAs (Monad MetaStateM); { pure := i.pure, bind := i.bind }
+instance : Monad MetaStateM := let i : Monad MetaStateM := inferInstance; { pure := i.pure, bind := i.bind }
 
 instance : MonadLCtx MetaStateM where
   getLCtx := return (← get).toContext.lctx

--- a/Auto/Lib/MonadUtils.lean
+++ b/Auto/Lib/MonadUtils.lean
@@ -125,8 +125,8 @@ private def elabGenMonadStateAux (m : Term) (stx : Syntax) : CommandElabM Unit :
     | throwError "{decl_name%} :: Unknown monad"
   let .str pre _ := mname
     | throwError "{decl_name%} :: {mname} is not a valid constant name"
-  let pureInst ← elabStx (← `(inferInstanceAs (Pure $m)))
-  let mstateInst ← elabStx (← `(inferInstanceAs (MonadState _ $m)))
+  let pureInst ← elabStx (← `((inferInstance : Pure $m)))
+  let mstateInst ← elabStx (← `((inferInstance : MonadState _ $m)))
   let mstateInstTy ← Meta.inferType mstateInst
   -- The type of the state of the Monad (with parameters applied)
   let stateTy := mstateInstTy.getArg! 0

--- a/Auto/Lib/Pos.lean
+++ b/Auto/Lib/Pos.lean
@@ -40,14 +40,13 @@ private theorem ofNat'WFAux (n n' : Nat) : n = n' + 2 → n / 2 < n := by
   case hLtK => apply Nat.le_refl
 
 def ofNat'WF (n : Nat) :=
-  match h : n with
+  match _ : n with
   | 0 => xH
   | 1 => xH
   | _ + 2 =>
     match n % 2 with
     | 0 => .xO (ofNat'WF (n / 2))
     | _ => .xI (ofNat'WF (n / 2))
-decreasing_by rw [h]; apply ofNat'WFAux _ _ rfl
 
 def ofNat'WF.inductionOn.{u}
   {motive : Nat → Sort u} (x : Nat)

--- a/Auto/Lib/ToExprExtra.lean
+++ b/Auto/Lib/ToExprExtra.lean
@@ -23,6 +23,7 @@ scoped instance : ToExpr Int where
   We require that `toExpr (self:=instExprToExprId (.const ``Nat [])) l₂ ≝ l₁`
   It is obvious that this shouldn't be marked as an `instance`
 -/
+@[implicit_reducible]
 def instExprToExprId (ty : Expr) : ToExpr Expr :=
   { toExpr := id, toTypeExpr := ty}
 

--- a/Auto/MathlibEmulator/ToLevel.lean
+++ b/Auto/MathlibEmulator/ToLevel.lean
@@ -35,10 +35,12 @@ instance [ToLevel.{u}] : ToLevel.{u+1} where
   toLevel := .succ toLevel.{u}
 
 /-- `ToLevel` for `max u v`. This is not an instance since it causes divergence. -/
+@[implicit_reducible]
 def ToLevel.max [ToLevel.{u}] [ToLevel.{v}] : ToLevel.{max u v} where
   toLevel := .max toLevel.{u} toLevel.{v}
 
 /-- `ToLevel` for `imax u v`. This is not an instance since it causes divergence. -/
+@[implicit_reducible]
 def ToLevel.imax [ToLevel.{u}] [ToLevel.{v}] : ToLevel.{imax u v} where
   toLevel := .imax toLevel.{u} toLevel.{v}
 

--- a/Auto/Translation/LamReif.lean
+++ b/Auto/Translation/LamReif.lean
@@ -1823,7 +1823,7 @@ open Embedding.Lam LamReif
 
   @[always_inline]
   instance : Monad TransM :=
-    let i := inferInstanceAs (Monad TransM);
+    let i : Monad TransM := inferInstance;
     { pure := i.pure, bind := i.bind }
 
   instance : Inhabited (TransM α) where

--- a/Auto/Translation/Reduction.lean
+++ b/Auto/Translation/Reduction.lean
@@ -9,6 +9,7 @@ private instance : ToString TransparencyMode where
   | .default   => "default"
   | .reducible => "reducible"
   | .instances => "instances"
+  | .none      => "none"
 
 private instance : Lean.KVMap.Value TransparencyMode where
   toDataValue t := toString t
@@ -17,6 +18,7 @@ private instance : Lean.KVMap.Value TransparencyMode where
   | "default"   => some .default
   | "reducible" => some .reducible
   | "instances" => some .instances
+  | "none"      => some .none
   | _           => none
 
 register_option auto.redMode : TransparencyMode := {

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.27.0
+leanprover/lean4:v4.28.0

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.28.0
+leanprover/lean4:v4.29.0


### PR DESCRIPTION
Builds on #64. Review #64 first.

Note: added `@[implicit_reducible]` to resolve new warnings regarding type-class instances. Those warnings appear even if `instance` keyword is not used!