### PR TITLE
fix: avoid variable capture in TH0 quantifier translation

### DIFF
--- a/Auto/IR/TPTP_TH0.lean
+++ b/Auto/IR/TPTP_TH0.lean
@@ -123,7 +123,7 @@ where
   expandQuantBody (s : LamSort) (t : LamTerm) : LamTerm :=
     match t with
     | .lam _ body => body
-    | _ => (LamTerm.app s t (.bvar 0)).headBeta
+    | _ => (LamTerm.app_bvarLift_bvar0 s t).headBeta
   transQuantApp (quant body : LamTerm) (lctx : Nat) : Except String String :=
     let info : Except String (String × LamSort) :=
       match quant with

--- a/Test/Test_Regression.lean
+++ b/Test/Test_Regression.lean
@@ -755,6 +755,29 @@ section TPTP
   example (f : ((Empty → Prop) → Prop) → Prop) :
     f Exists = f Exists := by auto
 
+  -- Regression tests for #72: expanding a non-lambda quantifier body must not
+  -- capture bound variables from the surrounding context.
+  #guard (Auto.Lam2TH0.transLamTerm
+      (.app (.func (.atom 0) (.base .prop)) (.base (.existE (.atom 0))) (.bvar 0)) 1).toOption ==
+    .some "(? [X1 : s_a0] : (X0 @ X1))"
+
+  #guard (Auto.Lam2TH0.transLamTerm
+      (.app (.func (.atom 0) (.base .prop)) (.base (.forallE (.atom 0))) (.bvar 0)) 1).toOption ==
+    .some "(! [X1 : s_a0] : (X0 @ X1))"
+
+  #guard (Auto.Lam2TH0.transLamTerm
+      (.app (.func (.atom 0) (.base .prop)) (.base (.forallE (.atom 0)))
+        (.lam (.atom 0)
+          (.app (.func (.atom 0) (.base .prop)) (.base (.existE (.atom 0)))
+            (.app (.atom 0) (.bvar 1) (.bvar 0))))) 1).toOption ==
+    .some "(! [X1 : s_a0] : (? [X2 : s_a0] : ((X0 @ X1) @ X2)))"
+
+  -- An explicit lambda body is stripped directly and must not be lifted again.
+  #guard (Auto.Lam2TH0.transLamTerm
+      (.app (.func (.atom 0) (.base .prop)) (.base (.existE (.atom 0)))
+        (.lam (.atom 0) (.app (.atom 0) (.bvar 1) (.bvar 0)))) 1).toOption ==
+    .some "(? [X1 : s_a0] : (X0 @ X1))"
+
 end TPTP
 
 -- Issues


### PR DESCRIPTION
Fixes #72.

When translating a quantifier applied to a non-lambda predicate, `transLamTerm` introduces a new binder and translates the predicate body under that binder. The previous implementation applied the predicate to `.bvar 0` without first lifting its loose de Bruijn variables.

As a result, an outer variable could be captured by the newly introduced quantifier, producing ill-typed TH0 such as `X1 @ X1` instead of `X0 @ X1`.

This change uses the existing `LamTerm.app_bvarLift_bvar0` helper to lift the predicate before applying it to the new bound variable. Explicit lambda bodies retain the existing path because their body already accounts for the binder.

Regression guards cover:

- existential quantifiers
- universal quantifiers
- nested quantifiers
- explicit lambda bodies, ensuring they are not lifted twice

Validation:

- `lake build` — passed, 247 jobs
- on `upstream/main`, the existential, universal, and nested regression guards fail as expected
- with this patch, all four regression guards pass
- Zipperposition rejects the previous `X1 @ X1` output with a type error and accepts the corrected `X0 @ X1` output
- `git diff --check upstream/main...HEAD` — passed

The added guards were also run in isolation because the complete `Test/Test_Regression.lean` file depends on locally configured external solvers.

Thanks to @nartannt for the detailed report and for suggesting the `bvarLift` fix.